### PR TITLE
Fix version on manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,5 +18,5 @@
 		"page": "options.html"
 	},
     "permissions": [ "cookies", "<all_urls>", "storage", "webRequest", "webRequestBlocking"],
-	"version": "1.2.11	"
+	"version": "1.2.11"
 }


### PR DESCRIPTION
Otherwise installation fails with:

> Chrome Required value 'version' is missing or invalid. It must be between 1-4 dot-separated integers each between 0 and 65536