### PR TITLE
Fix repubblica.it after page reload

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -6,9 +6,9 @@ if (location.hostname.endsWith('rep.repubblica.it')) {
   }
 
   if (location.href.includes('/ws/detail/')) {
-    const paywall = document.getElementsByClassName('paywall');
-    if (paywall && paywall.length > 0) {
-      paywall[0].toggleAttribute('amp-access-hide');
+    const paywall = document.querySelector('.paywall[amp-access-hide]');
+    if (paywall) {
+      paywall.removeAttribute('amp-access-hide');
     }
   }
 }


### PR DESCRIPTION
This PR fixes [the previous one](https://github.com/iamadamdev/bypass-paywalls-chrome/pull/70) as I noticed that the page triggers a _ping_ to an external service and keeps toggling the hidden div with the real content.