### PR TITLE
Fix repubblica.it after website update

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -6,9 +6,13 @@ if (location.hostname.endsWith('rep.repubblica.it')) {
   }
 
   if (location.href.includes('/ws/detail/')) {
-    const paywall = document.querySelector('.paywall[amp-access-hide]');
+    const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
     if (paywall) {
-      paywall.removeAttribute('amp-access-hide');
+      paywall.removeAttribute('subscriptions-section');
+      const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
+      if (preview) {
+        preview.remove();
+      }
     }
   }
 }


### PR DESCRIPTION
Repubblica.it paywall changed a few days ago, as reported in #98.

This PR provides a fix to match the new markup structure.