### PR TITLE
PR: ED.nl & Telegraaf.nl

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Quora (quora.com)\
 San Francisco Chronicle (sfchronicle.com)\
 Scientific American (scientificamerican.com)\
 SunSentinel (sun-sentinel.com)\
+Telegraaf (telegraaf.nl)\
 The Advocate (theadvocate.com.au)\
 The Age (theage.com.au)\
 The Australian (theaustralian.com.au)\

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Denver Post (denverpost.com)\
 Dynamed Plus (dynamed.com)\
 The Economist (economist.com)\
 Encyclopedia Britannica (britannica.com)\
+Eindhovens Dagblad (ed.nl)\
 Examiner (examiner.com.au)\
 Financial News (fnlondon.com)\
 Financial Times (ft.com)\

--- a/background.js
+++ b/background.js
@@ -17,6 +17,7 @@ var defaultSites = {
   'Dynamed Plus': 'dynamed.com',
   'The Economist': 'economist.com',
   'Les Echos': 'lesechos.fr',
+  'Eindhovens Dagblad': 'ed.nl',
   'Encyclopedia Britannica': 'britannica.com',
   'Examiner': 'examiner.com.au',
   'Financial News': 'fnlondon.com',
@@ -105,6 +106,7 @@ const allow_cookies = [
 // Removes cookies after page load
 const remove_cookies = [
 'asia.nikkei.com',
+'ed.nl'
 'ft.com',
 'fd.nl',
 'mercurynews.com',

--- a/background.js
+++ b/background.js
@@ -46,6 +46,7 @@ var defaultSites = {
   'San Francisco Chronicle': 'sfchronicle.com',
   'Scientific American': 'scientificamerican.com',
   'SunSentinel': 'sun-sentinel.com',
+  'Telegraaf': 'telegraaf.nl',
   'The Advocate': 'theadvocate.com.au',
   'The Age': 'theage.com.au',
   'The Australian': 'theaustralian.com.au',
@@ -97,6 +98,7 @@ const allow_cookies = [
 'washingtonpost.com',
 'nymag.com',
 'theaustralian.com.au',
+'telegraaf.nl', // keep accept cookies
 'demorgen.be',
 ]
 
@@ -128,6 +130,7 @@ const remove_cookies = [
 'nymag.com',
 'foreignaffairs.com',
 'scientificamerican.com',
+'telegraaf.nl',
 'thestar.com',
 'qz.com',
 'demorgen.be',

--- a/contentScript.js
+++ b/contentScript.js
@@ -25,3 +25,10 @@ if (window.location.href.indexOf("americanbanker.com") !== -1) {
     paywall[0].className = "";
   }
 }
+
+if (window.location.href.indexOf('telegraaf.nl') !== -1) {
+  const paywall = document.getElementById('TEMPRORARY_METERING_ID');
+  if (paywall) {
+    window.location.reload(1);
+  }
+}

--- a/contentScript.js
+++ b/contentScript.js
@@ -32,3 +32,11 @@ if (window.location.href.indexOf('telegraaf.nl') !== -1) {
     window.location.reload(1);
   }
 }
+
+if (window.location.href.indexOf('ed.nl') !== -1) {
+  const paywall = document.querySelector('.article__component.article__component--paywall-module-notification');
+  if (paywall) {
+    paywall.remove();
+    paywall = null;
+  }
+}

--- a/options.js
+++ b/options.js
@@ -15,6 +15,7 @@ var defaultSites = {
   'Dynamed Plus': 'dynamed.com',
   'The Economist (javascript disabled)': 'economist.com',
   'Encyclopedia Britannica': 'britannica.com',
+  'Eindhovens Dagblad': 'ed.nl',
   'Examiner': 'examiner.com.au',
   'Financial News': 'fnlondon.com',
   'Financial Times': 'ft.com',

--- a/options.js
+++ b/options.js
@@ -44,6 +44,7 @@ var defaultSites = {
   'San Francisco Chronicle': 'sfchronicle.com',
   'Scientific American': 'scientificamerican.com',
   'SunSentinel': 'sun-sentinel.com',
+  'Telegraaf': 'telegraaf.nl',
   'The Advocate': 'theadvocate.com.au',
   'The Age': 'theage.com.au',
   'The Australian': 'theaustralian.com.au',


### PR DESCRIPTION
This PR adds the following domains to the chrome extension:

- [Eindhovens Dagblad](https://www.ed.nl/)
- [Telegraaf](https://www.telegraaf.nl/)

These are Dutch only news sites that use a form of a paywall.