### PR TITLE
Add Washingtonpost.com automatic GDPR bypass

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -40,3 +40,17 @@ if (window.location.href.indexOf('ed.nl') !== -1) {
     paywall = null;
   }
 }
+
+if (window.location.href.indexOf("washingtonpost.com") !== -1) {
+  if (location.href.includes('/gdpr-consent/')) {
+    document.querySelector('.gdpr-consent-container .continue-btn.button.free').click();
+
+    const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
+    if (gdprcheckbox) {
+      gdprcheckbox.checked = true;
+      gdprcheckbox.dispatchEvent(new Event('change'));
+
+      document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
+    }
+  }
+}


### PR DESCRIPTION
I've added a statement that automatically clicks through the GDPR pages on Washingtonpost.com that EU users experience on every single article, making the experience for them vastly smoother.

Here's two quick videos showing the improvement:
Before: https://streamable.com/msp3y
After: https://streamable.com/0e2my