### PR TITLE
Add Statista

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 [Quora](https://www.quora.com)\
 [San Francisco Chronicle](https://sfchronicle.com)\
 [Scientific American](https://scientificamerican.com)\
+[Statista](https://statista.com)\
 [SunSentinel](https://www.sun-sentinel.com)\
 [Telegraaf](https://telegraaf.nl)\
 [The Advocate](https://www.theadvocate.com.au)\

--- a/background.js
+++ b/background.js
@@ -47,6 +47,7 @@ var defaultSites = {
   'San Francisco Chronicle': 'sfchronicle.com',
   'Scientific American': 'scientificamerican.com',
   'SunSentinel': 'sun-sentinel.com',
+  'Statista':'statista.com',
   'Telegraaf': 'telegraaf.nl',
   'The Advocate': 'theadvocate.com.au',
   'The Age': 'theage.com.au',

--- a/options.js
+++ b/options.js
@@ -44,6 +44,7 @@ var defaultSites = {
   'Quora': 'quora.com',
   'San Francisco Chronicle': 'sfchronicle.com',
   'Scientific American': 'scientificamerican.com',
+  'Statista': 'statista.com',
   'SunSentinel': 'sun-sentinel.com',
   'Telegraaf': 'telegraaf.nl',
   'The Advocate': 'theadvocate.com.au',


### PR DESCRIPTION
Add Statista, a statistics company that charges after you look at a graph once. 