### PR TITLE
Add World Politics Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 [Vanity Fair](https://www.vanityfair.com)\
 [Winston-Salem Journal](https://journalnow.com)\
 [Wired](https://www.wired.com)\
+[World Politics Review](https://www.worldpoliticsreview.com)\
 [Zeit Online](https://www.zeit.de)
 
 ### Sites with limited number of free articles

--- a/background.js
+++ b/background.js
@@ -74,6 +74,7 @@ var defaultSites = {
   'Winston-Salem Journal': 'journalnow.com',
   'Vanity Fair': 'vanityfair.com',
   'Wired': 'wired.com',
+  'World Politics Review': 'worldpoliticsreview.com',
   'Zeit Online': 'zeit.de'
 };
 
@@ -146,6 +147,7 @@ const use_google_bot = [
 'theaustralian.com.au',
 'barrons.com',
 'telegraph.co.uk',
+'worldpoliticsreview'.com,
 'zeit.de'
 ]
 

--- a/options.js
+++ b/options.js
@@ -72,6 +72,7 @@ var defaultSites = {
   'Winston-Salem Journal': 'journalnow.com',
   'Vanity Fair': 'vanityfair.com',
   'Wired': 'wired.com',
+  'World Politics review': 'worldpoliticsreview.com',
   'Zeit Online': 'zeit.de'
 };
 


### PR DESCRIPTION
This PR adds World Politics Review ( https://www.worldpoliticsreview.com ) to the list.

**Testing**
The changes were tested on Chrome (developer mode).

1. Load the extension and deselect World Politics Review
2. Load https://www.worldpoliticsreview.com/articles/27571/can-israel-s-new-right-turn-west-bank-settlers-against-netanyahu (or any article)
3. Scroll down and check that there is a paywall
4. Select World Politics Review and reload the page
5. Check that the entire article is displayed