### PR TITLE
Add handelsblatt.com support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 [Glassdoor](https://www.glassdoor.com)\
 [Haaretz.co.il](https://www.haaretz.co.il)\
 [Haaretz.com](https://www.haaretz.com)\
+[Handelsblatt](https://www.handelsblatt.com)\
 [Harper's Magazine](https://harpers.org)\
 [Hartford Courant](https://www.courant.com)\
 [Harvard Business Review](https://www.hbr.org)\

--- a/background.js
+++ b/background.js
@@ -26,6 +26,7 @@ var defaultSites = {
   'Glassdoor': 'glassdoor.com',
   'Haaretz': 'haaretz.co.il',
   'Haaretz English': 'haaretz.com',
+  'Handelsblatt': 'handelsblatt.com',
   'Hartford Courant': 'courant.com',
   'Harper\'s Magazine': 'harpers.org',
   'Harvard Business Review': 'hbr.org',
@@ -140,6 +141,7 @@ const remove_cookies = [
 'demorgen.be',
 'sloanreview.mit.edu',
 'zeit.de',
+'handelsblatt.com',
 ]
 
 // Override User-Agent with Googlebot

--- a/options.js
+++ b/options.js
@@ -23,6 +23,7 @@ var defaultSites = {
   'Glassdoor': 'glassdoor.com',
   'Haaretz': 'haaretz.co.il',
   'Haaretz English': 'haaretz.com',
+  'Handelsblatt': 'handelsblatt.com',
   'Harper\'s Mag': 'harpers.org',
   'Hartford Courant': 'courant.com',
   'Harvard Business Review': 'hbr.org',


### PR DESCRIPTION
Add handelsblatt.com support. Copied from Firefox Addon