### PR TITLE
Fix the NYT issue

### DIFF
--- a/background.js
+++ b/background.js
@@ -171,6 +171,7 @@ const use_google_bot = [
 'telegraph.co.uk',
 'zeit.de',
 'mexiconewsdaily.com',
+'nytimes.com',
 'thetimes.co.uk',
 ]
 


### PR DESCRIPTION
Just added nytimes.com to the Google referrer list. Seems to be a Mac-only issue