### PR TITLE
Fix The Atlantic & Bloomberg & Telegraaf.nl/Ad.nl/Ed.nl

### DIFF
--- a/background.js
+++ b/background.js
@@ -191,6 +191,12 @@ const remove_cookies_select_hold = {
 
 // select only specific cookie(s) to drop from remove_cookies domains
 const remove_cookies_select_drop = {
+	'.ad.nl': ['temptationTrackingId'],
+	'.www.ad.nl': ['none'],
+	'www.ad.nl': ['none'],
+	'.ed.nl': ['temptationTrackingId'],
+	'.www.ed.nl': ['none'],
+	'www.ed.nl': ['none'],
 	'www.nrc.nl': ['counter']
 }
 
@@ -215,7 +221,6 @@ function setDefaultOptions() {
     chrome.tabs.create({ 'url': 'chrome://extensions/?options=' + chrome.runtime.id });
   });
 }
-
 
 var blockedRegexes = [
 /.+:\/\/.+\.tribdss\.com\//,

--- a/background.js
+++ b/background.js
@@ -140,6 +140,7 @@ const allow_cookies = [
 'the-american-interest.com',
 'theadvocate.com.au',
 'theage.com.au',
+'theatlantic.com',
 'theaustralian.com.au',
 'trouw.nl',
 'vn.nl',
@@ -175,6 +176,7 @@ const remove_cookies = [
 'telegraaf.nl',
 'theadvocate.com.au',
 'theage.com.au',
+'theatlantic.com',
 'vn.nl',
 'washingtonpost.com',
 'wsj.com'

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,141 +1,102 @@
 window.localStorage.clear();
-
-if (location.hostname.endsWith('rep.repubblica.it')) {
-    if (location.href.includes('/pwa/')) {
-        location.href = location.href.replace('/pwa/', '/ws/detail/');
-    }
-
-    if (location.href.includes('/ws/detail/')) {
-        const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
-        if (paywall) {
-            paywall.removeAttribute('subscriptions-section');
-            const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
-            if (preview) {
-                preview.remove();
-            }
-        }
-    }
-}
-
-if (window.location.href.indexOf("americanbanker.com") !== -1) {
-	const paywall = document.getElementsByClassName(
-		"embargo-content"
+if (window.location.href.indexOf("bizjournals.com") !== -1) {
+	const hiddenStory = document.getElementsByClassName(
+		"js-pre-chunks__story-body"
 	);
-	if (paywall && paywall.length > 0) {
-		paywall[0].className = "";
+	if (hiddenStory && hiddenStory.length > 0) {
+		hiddenStory[0].style.display = "block";
 	}
-}
 
-if (window.location.href.indexOf('telegraaf.nl') !== -1) {
-    const paywall = document.getElementById('TEMPRORARY_METERING_ID');
-    if (paywall) {
-        window.location.reload(1);
-    }
-}
-
-if (window.location.href.indexOf('ed.nl') !== -1) {
-	let paywall = document.querySelector('.article__component.article__component--paywall-module-notification');
-	if (paywall) {
-		paywall.remove();
-		paywall = null;
+	const payWallMessage = document.getElementsByClassName(
+		"chunk chunk--flex@lg chunk--paywall"
+	);
+	if (payWallMessage && payWallMessage.length > 0) {
+		payWallMessage[0].style.display = "none";
 	}
-}
-
-if (window.location.href.indexOf("washingtonpost.com") !== -1) {
-    if (location.href.includes('/gdpr-consent/')) {
-        const free_button = document.querySelector('.gdpr-consent-container .continue-btn.button.free');
-        if (free_button)
-            free_button.click();
-
-        setTimeout(function () {
-            const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
-            if (gdprcheckbox) {
-                gdprcheckbox.checked = true;
-                gdprcheckbox.dispatchEvent(new Event('change'));
-
-                document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
-            }
-        }, 300); // Delay (in milliseconds)
-    }
-}
-
-if (window.location.href.indexOf("wsj.com") !== -1) {
-    if (location.href.includes('/articles/')) {
-		const close_button = document.querySelector('.close-btn');
-		if (close_button)
-			close_button.click();
-    }
-}
-
-if (window.location.href.indexOf("sloanreview.mit.edu") !== -1) {
-    document.querySelector('#cboxClose').click();
-}
-
-if (window.location.href.indexOf("mexiconewsdaily.com") !== -1) {
-    document.addEventListener('DOMContentLoaded', () => {
-        const sideNotification = document.querySelector('.pigeon-widget-prompt');
-        const subMessage = document.querySelector('.sub_message_container');
-        const popup = document.querySelector('.popupally-pro-outer-full-width-7-fluid_qemskqa');
-        const bgFocusRemoverId = document.getElementById('popup-box-pro-gfcr-7');
-
-        removeDOMElement(sideNotification, subMessage, popup, bgFocusRemoverId);
-    });
-}
-
-if (window.location.href.indexOf("the-american-interest.com") !== -1) {
-  const counter = document.getElementById('article-counter') || false;
-  if (counter) {
-	counter.remove();
-	counter = false; 
-  }
-}
-
-if (window.location.href.indexOf("nzherald.co.nz") !== -1) {
-	const paywall = document.getElementById('article-content');
+} else if (window.location.href.indexOf("businessinsider.com") !== -1) {
+	const paywall = document.getElementsByClassName(
+		"tp-modal"
+	);
+	while (paywall.length > 0) {
+		paywall[0].parentNode.removeChild(paywall[0]);
+	}
+} else if (location.hostname.endsWith('haaretz.co.il')) {
+	const html = document.getElementsByTagName('html');
+	if (html && html.length > 0) {
+		html[0].style['overflow-y'] = 'auto';
+	}
+	const msg = document.getElementById('article-wrapper');
+	if (msg) {
+		msg.style['display'] = 'none';
+	}
+} else if (window.location.href.indexOf("nzherald.co.nz") !== -1) {
+	const paywall = document.getElementById(
+		"article-content"
+	);
 	if (paywall) {
-		const premium = document.getElementsByClassName('premium-sub')[0];
-		removeDOMElement(premium);
 		paywall.classList.remove('premium-content');
 		paywall.classList.add('full-content');
-		removeClassesByPrefix(paywall, 'QUnW');
 		var paras = paywall.querySelectorAll("p, span, h2, div");
-		for (var i = 0; i < paras.length; i++){		
-			removeClassesByPrefix(paras[i], 'QUnW');
-			paras[i].classList.remove("ellipsis");
+		var delClass = "";
+		for (var i = 0; i < paras.length; i++) {
+			if (paras[i].nodeName == 'P' || paras[i].nodeName == 'SPAN') {
+				paras[i].classList.remove("ellipsis");
+				if (delClass == "" && paras[i].className != "") {
+					delClass = paras[i].className;
+				} else {
+					if (delClass != "") {
+						paras[i].classList.remove(delClass);
+					}
+				}
+			}
 			paras[i].removeAttribute('style');
 		}
 	}
-} 
+} else if (location.hostname.endsWith('rep.repubblica.it')) {
+	if (location.href.includes("/pwa/")) {
+		location.href = location.href.replace("/pwa/", "/ws/detail/");
+	}
 
-if (window.location.href.indexOf("parool.nl") !== -1 || window.location.href.indexOf("trouw.nl") !== -1 || window.location.href.indexOf("volkskrant.nl") !== -1) {
-	document.addEventListener('DOMContentLoaded', () => {
-		const paywall = document.querySelector('div[data-temptation-position="ARTICLE_BOTTOM"]');
-		const hidden_section = document.querySelector('div[data-temptation-position="ARTICLE_INLINE"]');
-		removeDOMElement(paywall, hidden_section);
-	});
-}
+	if (location.href.includes("/ws/detail/")) {
+		const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
+		if (paywall) {
+			paywall.removeAttribute('subscriptions-section');
+			const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
+			if (preview) {
+				preview.remove();
+			}
+		}
+	}
+} else if (window.location.href.indexOf("wsj.com") !== -1) {
+	if (location.href.includes('/articles/')) {
+		document.addEventListener('DOMContentLoaded', () => {
+			const paywall = document.getElementById('cx-scrim');
+			const candybar = document.getElementById('cx-candybar');
+			removeDOMElement(paywall, candybar);
+		});
+		/**
+		setTimeout(function () {
+			const close_button = document.querySelector('.close-btn');
+			if (close_button)
+				close_button.click();
+		}, 2000);
+		**/
+	}
+} else if (window.location.href.indexOf("washingtonpost.com") !== -1) {
+	if (location.href.includes('/gdpr-consent/')) {
+		document.querySelector('.gdpr-consent-container .continue-btn.button.free').click();
 
-if (window.location.href.indexOf("firstthings.com") !== -1) {
-    const paywall = document.getElementsByClassName('paywall')[0];
+		setTimeout(function () {
 
-  if (paywall)
-        removeDOMElement(paywall);
-}
+			const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
+			if (gdprcheckbox) {
+				gdprcheckbox.checked = true;
+				gdprcheckbox.dispatchEvent(new Event('change'));
 
-if (window.location.href.indexOf("bloomberg.com") !== -1) {
-    document.addEventListener('DOMContentLoaded', () => {
-		const fence = document.querySelector('.fence-body');
-		if (fence)
-			fence.classList.remove('fence-body');
-		const paywall = document.getElementById('paywall-banner');
-		removeDOMElement(paywall);
-    });
-}
-
-if (window.location.href.indexOf("bloombergquint.com") !== -1) {
-    const articlesLeftModal = document.getElementsByClassName('paywall-meter-module__story-paywall-container__1UgCE')[0];
-    const paywall = document.getElementById('paywallDmp');
-    removeDOMElement(articlesLeftModal, paywall);
+				document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
+			}
+		}, 300); // Delay (in milliseconds)
+	}
 }
 
 if (window.location.href.indexOf("medium.com") !== -1) {
@@ -143,6 +104,47 @@ if (window.location.href.indexOf("medium.com") !== -1) {
 	const DOMElementsToTextDiv = pageContains('div', bottomMessageText);
 
 	if (DOMElementsToTextDiv[2]) removeDOMElement(DOMElementsToTextDiv[2]);
+}
+
+if (window.location.href.indexOf("bloombergquint.com") !== -1) {
+	const articlesLeftModal = document.getElementsByClassName('paywall-meter-module__story-paywall-container__1UgCE')[0];
+	const paywall = document.getElementById('paywallDmp');
+	removeDOMElement(articlesLeftModal,	paywall);
+}
+
+if (window.location.href.indexOf("bloomberg.com") !== -1) {
+    document.addEventListener('DOMContentLoaded', () => {
+		const fence = document.querySelector('.fence-body');
+		if (fence)
+			fence.classList.remove('fence-body');
+        const paywall = document.getElementById('paywall-banner');
+        removeDOMElement(paywall);
+    });
+}
+
+if (window.location.href.indexOf('telegraaf.nl') !== -1) {
+	setTimeout(function () {
+		const paywall = document.getElementById('TEMPRORARY_METERING_ID');
+		if (paywall) {
+			window.location.reload(true);
+		}
+	}, 500); // Delay (in milliseconds)
+}
+
+if (window.location.href.indexOf('ed.nl') !== -1) {
+	const paywall = document.querySelector('.article__component.article__component--paywall-module-notification');
+	if (paywall) {
+		paywall.remove();
+		paywall = null;
+	}
+}
+
+if (window.location.href.indexOf("parool.nl") !== -1 ||	window.location.href.indexOf("trouw.nl") !== -1 || 	window.location.href.indexOf("volkskrant.nl") !== -1) {
+	document.addEventListener('DOMContentLoaded', () => {
+		const paywall = document.querySelector('div[data-temptation-position="ARTICLE_BOTTOM"]');
+		const hidden_section = document.querySelector('div[data-temptation-position="ARTICLE_INLINE"]');
+		removeDOMElement(paywall, hidden_section);
+	});
 }
 
 if (window.location.href.indexOf('lemonde.fr') !== -1) {
@@ -162,71 +164,32 @@ if (window.location.href.indexOf('lemonde.fr') !== -1) {
         removeDOMElement(paywall, friend_paywall, cookie_banner);
     });
 }
-	
-if (window.location.href.indexOf("canberratimes.com.au") !== -1) {
-    
-        const paywall = document.querySelector('.subscribe-article.news-article-body.article__body');
-        paywall.classList.remove('subscribe-article');
-
-        var subscribe = document.getElementsByClassName('subscriber-container')[0];
-        removeDOMElement(subscribe);
-    
-        var content = document.getElementsByClassName('subscriber-hider');
-        for (var i = 0; i < content.length; i++) {
-        content[i].classList.remove('subscriber-hider');
-    }
-}
-
-if (window.location.href.indexOf("ledevoir.com") !== -1) {
-
-        const counter = document.querySelector('.full.hidden-print.popup-msg');
-        removeDOMElement(counter);
-}
-
-if (window.location.href.indexOf("thehindu.com") !== -1) {
-  
-         const paywall = document.getElementById('test');
-        removeDOMElement(paywall);
-}
 
 if (window.location.href.indexOf("nytimes.com") !== -1) {
-
     const preview_button = document.querySelector('.css-3s1ce0');
         if (preview_button)
             preview_button.click();
 }
 
-if (window.location.href.indexOf("leparisien.fr") !== -1) {
-		window.removeEventListener('scroll', this.scrollListener);
-
-        const paywall = document.querySelector('.relative.piano-paywall.below_nav.sticky');
-        removeDOMElement(paywall);
-
-        setTimeout(function () {
-			var content = document.getElementsByClassName('content');
-			for (var i = 0; i < content.length; i++) {
-				content[i].removeAttribute("style");
-			}
-		}, 300); // Delay (in milliseconds)
+if (window.location.href.indexOf("caixinglobal.com") !== -1) {
+	const appContent = document.getElementById('appContent');
+	if (appContent) {
+		const p_hidden = document.querySelectorAll('p:not([style="display:block;"]');
+		for (var i = 0; i < p_hidden.length; i++) {
+			p_hidden[i].setAttribute('style', 'display:block;');
+		}
+	}
 }
 
 function removeDOMElement(...elements) {
-    for (let element of elements) {
-        if (element)
-            element.remove();
-    }
-}
-
-function removeClassesByPrefix(el, prefix) {
-	for (var i = 0; i < el.classList.length; i++){
-        if(el.classList[i].startsWith(prefix)) {
-            el.classList.remove(el.classList[i]);
-        }
-    }
+	for (let element of elements) {
+		if (element) element.remove();
+	}
 }
 
 function pageContains(selector, text) {
 	let elements = document.querySelectorAll(selector);
+
 	return Array.prototype.filter.call(elements, function(element){
 		return RegExp(text).test(element.textContent);
 	});

--- a/contentScript.js
+++ b/contentScript.js
@@ -127,6 +127,8 @@ if (window.location.href.indexOf("bloomberg.com") !== -1) {
 		const fence = document.querySelector('.fence-body');
 		if (fence)
 			fence.classList.remove('fence-body');
+		const paywall = document.getElementById('paywall-banner');
+		removeDOMElement(paywall);
     });
 }
 

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,125 +1,26 @@
 window.localStorage.clear();
-if (window.location.href.indexOf("bizjournals.com") !== -1) {
-	const hiddenStory = document.getElementsByClassName(
-		"js-pre-chunks__story-body"
-	);
-	if (hiddenStory && hiddenStory.length > 0) {
-		hiddenStory[0].style.display = "block";
-	}
 
-	const payWallMessage = document.getElementsByClassName(
-		"chunk chunk--flex@lg chunk--paywall"
-	);
-	if (payWallMessage && payWallMessage.length > 0) {
-		payWallMessage[0].style.display = "none";
-	}
-} else if (window.location.href.indexOf("businessinsider.com") !== -1) {
-	const paywall = document.getElementsByClassName(
-		"tp-modal"
-	);
-	while (paywall.length > 0) {
-		paywall[0].parentNode.removeChild(paywall[0]);
-	}
-} else if (location.hostname.endsWith('haaretz.co.il')) {
-	const html = document.getElementsByTagName('html');
-	if (html && html.length > 0) {
-		html[0].style['overflow-y'] = 'auto';
-	}
-	const msg = document.getElementById('article-wrapper');
-	if (msg) {
-		msg.style['display'] = 'none';
-	}
-} else if (window.location.href.indexOf("nzherald.co.nz") !== -1) {
-	const paywall = document.getElementById(
-		"article-content"
-	);
-	if (paywall) {
-		paywall.classList.remove('premium-content');
-		paywall.classList.add('full-content');
-		var paras = paywall.querySelectorAll("p, span, h2, div");
-		var delClass = "";
-		for (var i = 0; i < paras.length; i++) {
-			if (paras[i].nodeName == 'P' || paras[i].nodeName == 'SPAN') {
-				paras[i].classList.remove("ellipsis");
-				if (delClass == "" && paras[i].className != "") {
-					delClass = paras[i].className;
-				} else {
-					if (delClass != "") {
-						paras[i].classList.remove(delClass);
-					}
-				}
-			}
-			paras[i].removeAttribute('style');
-		}
-	}
-} else if (location.hostname.endsWith('rep.repubblica.it')) {
-	if (location.href.includes("/pwa/")) {
-		location.href = location.href.replace("/pwa/", "/ws/detail/");
-	}
+if (location.hostname.endsWith('rep.repubblica.it')) {
+    if (location.href.includes('/pwa/')) {
+        location.href = location.href.replace('/pwa/', '/ws/detail/');
+    }
 
-	if (location.href.includes("/ws/detail/")) {
-		const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
-		if (paywall) {
-			paywall.removeAttribute('subscriptions-section');
-			const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
-			if (preview) {
-				preview.remove();
-			}
-		}
-	}
-} else if (window.location.href.indexOf("wsj.com") !== -1) {
-	if (location.href.includes('/articles/')) {
-		document.addEventListener('DOMContentLoaded', () => {
-			const paywall = document.getElementById('cx-scrim');
-			const candybar = document.getElementById('cx-candybar');
-			removeDOMElement(paywall, candybar);
-		});
-		/**
-		setTimeout(function () {
-			const close_button = document.querySelector('.close-btn');
-			if (close_button)
-				close_button.click();
-		}, 2000);
-		**/
-	}
-} else if (window.location.href.indexOf("washingtonpost.com") !== -1) {
-	if (location.href.includes('/gdpr-consent/')) {
-		document.querySelector('.gdpr-consent-container .continue-btn.button.free').click();
-
-		setTimeout(function () {
-
-			const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
-			if (gdprcheckbox) {
-				gdprcheckbox.checked = true;
-				gdprcheckbox.dispatchEvent(new Event('change'));
-
-				document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
-			}
-		}, 300); // Delay (in milliseconds)
-	}
+    if (location.href.includes('/ws/detail/')) {
+        const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
+        if (paywall) {
+            paywall.removeAttribute('subscriptions-section');
+            const preview = document.querySelector('div[subscriptions-section="content-not-granted"]');
+            if (preview) {
+                preview.remove();
+            }
+        }
+    }
 }
 
-if (window.location.href.indexOf("medium.com") !== -1) {
-	const bottomMessageText = 'Get one more story in your member preview when you sign up. It’s free.';
-	const DOMElementsToTextDiv = pageContains('div', bottomMessageText);
-
-	if (DOMElementsToTextDiv[2]) removeDOMElement(DOMElementsToTextDiv[2]);
-}
-
-if (window.location.href.indexOf("bloombergquint.com") !== -1) {
-	const articlesLeftModal = document.getElementsByClassName('paywall-meter-module__story-paywall-container__1UgCE')[0];
-	const paywall = document.getElementById('paywallDmp');
-	removeDOMElement(articlesLeftModal,	paywall);
-}
-
-if (window.location.href.indexOf("bloomberg.com") !== -1) {
-    document.addEventListener('DOMContentLoaded', () => {
-		const fence = document.querySelector('.fence-body');
-		if (fence)
-			fence.classList.remove('fence-body');
-        const paywall = document.getElementById('paywall-banner');
-        removeDOMElement(paywall);
-    });
+if (window.location.href.indexOf("americanbanker.com") !== -1) {
+	const paywall = document.getElementsByClassName('embargo-content')[0];
+	if (paywall)
+		paywall.classList.remove('embargo-content');
 }
 
 if (window.location.href.indexOf('telegraaf.nl') !== -1) {
@@ -128,23 +29,111 @@ if (window.location.href.indexOf('telegraaf.nl') !== -1) {
 		if (paywall) {
 			window.location.reload(true);
 		}
-	}, 500); // Delay (in milliseconds)
+	}, 1000); // Delay (in milliseconds)
 }
 
-if (window.location.href.indexOf('ed.nl') !== -1) {
-	const paywall = document.querySelector('.article__component.article__component--paywall-module-notification');
+if (window.location.href.indexOf('ad.nl') !== -1 || window.location.href.indexOf('ed.nl') !== -1) {
+	let paywall = document.querySelector('.article__component.article__component--paywall-module-notification');
+	removeDOMElement(paywall);
+}
+
+if (window.location.href.indexOf("washingtonpost.com") !== -1) {
+    if (location.href.includes('/gdpr-consent/')) {
+        const free_button = document.querySelector('.gdpr-consent-container .continue-btn.button.free');
+        if (free_button)
+            free_button.click();
+
+        setTimeout(function () {
+            const gdprcheckbox = document.querySelector('.gdpr-consent-container .consent-page:not(.hide) #agree');
+            if (gdprcheckbox) {
+                gdprcheckbox.checked = true;
+                gdprcheckbox.dispatchEvent(new Event('change'));
+
+                document.querySelector('.gdpr-consent-container .consent-page:not(.hide) .continue-btn.button.accept-consent').click();
+            }
+        }, 300); // Delay (in milliseconds)
+    }
+}
+
+if (window.location.href.indexOf("wsj.com") !== -1) {
+    if (location.href.includes('/articles/')) {
+		const close_button = document.querySelector('.close-btn');
+		if (close_button)
+			close_button.click();
+    }
+}
+
+if (window.location.href.indexOf("sloanreview.mit.edu") !== -1) {
+    document.querySelector('#cboxClose').click();
+}
+
+if (window.location.href.indexOf("mexiconewsdaily.com") !== -1) {
+    document.addEventListener('DOMContentLoaded', () => {
+        const sideNotification = document.querySelector('.pigeon-widget-prompt');
+        const subMessage = document.querySelector('.sub_message_container');
+        const popup = document.querySelector('.popupally-pro-outer-full-width-7-fluid_qemskqa');
+        const bgFocusRemoverId = document.getElementById('popup-box-pro-gfcr-7');
+
+        removeDOMElement(sideNotification, subMessage, popup, bgFocusRemoverId);
+    });
+}
+
+if (window.location.href.indexOf("the-american-interest.com") !== -1) {
+  const counter = document.getElementById('article-counter');
+  removeDOMElement(counter);
+}
+
+if (window.location.href.indexOf("nzherald.co.nz") !== -1) {
+	const paywall = document.getElementById('article-content');
 	if (paywall) {
-		paywall.remove();
-		paywall = null;
+		const premium = document.getElementsByClassName('premium-sub')[0];
+		removeDOMElement(premium);
+		paywall.classList.remove('premium-content');
+		paywall.classList.add('full-content');
+		removeClassesByPrefix(paywall, 'QUnW');
+		var paras = paywall.querySelectorAll("p, span, h2, div");
+		for (var i = 0; i < paras.length; i++){		
+			removeClassesByPrefix(paras[i], 'QUnW');
+			paras[i].classList.remove("ellipsis");
+			paras[i].removeAttribute('style');
+		}
 	}
-}
+} 
 
-if (window.location.href.indexOf("parool.nl") !== -1 ||	window.location.href.indexOf("trouw.nl") !== -1 || 	window.location.href.indexOf("volkskrant.nl") !== -1) {
+if (window.location.href.indexOf("parool.nl") !== -1 || window.location.href.indexOf("trouw.nl") !== -1 || window.location.href.indexOf("volkskrant.nl") !== -1) {
 	document.addEventListener('DOMContentLoaded', () => {
 		const paywall = document.querySelector('div[data-temptation-position="ARTICLE_BOTTOM"]');
 		const hidden_section = document.querySelector('div[data-temptation-position="ARTICLE_INLINE"]');
 		removeDOMElement(paywall, hidden_section);
 	});
+}
+
+if (window.location.href.indexOf("firstthings.com") !== -1) {
+    const paywall = document.getElementsByClassName('paywall')[0];
+	removeDOMElement(paywall);
+}
+
+if (window.location.href.indexOf("bloomberg.com") !== -1) {
+    document.addEventListener('DOMContentLoaded', () => {
+		const fence = document.querySelector('.fence-body');
+		if (fence){
+			fence.classList.remove('fence-body');
+		}
+		const paywall = document.getElementById('paywall-banner');
+		removeDOMElement(paywall);
+    });
+}
+
+if (window.location.href.indexOf("bloombergquint.com") !== -1) {
+    const articlesLeftModal = document.getElementsByClassName('paywall-meter-module__story-paywall-container__1UgCE')[0];
+    const paywall = document.getElementById('paywallDmp');
+    removeDOMElement(articlesLeftModal, paywall);
+}
+
+if (window.location.href.indexOf("medium.com") !== -1) {
+	const bottomMessageText = 'Get one more story in your member preview when you sign up. It’s free.';
+	const DOMElementsToTextDiv = pageContains('div', bottomMessageText);
+	if (DOMElementsToTextDiv[2]) removeDOMElement(DOMElementsToTextDiv[2]);
 }
 
 if (window.location.href.indexOf('lemonde.fr') !== -1) {
@@ -164,6 +153,27 @@ if (window.location.href.indexOf('lemonde.fr') !== -1) {
         removeDOMElement(paywall, friend_paywall, cookie_banner);
     });
 }
+	
+if (window.location.href.indexOf("canberratimes.com.au") !== -1) {
+        const paywall = document.querySelector('.subscribe-article.news-article-body.article__body');
+        paywall.classList.remove('subscribe-article');
+        var subscribe = document.getElementsByClassName('subscriber-container')[0];
+        removeDOMElement(subscribe);
+        var content = document.getElementsByClassName('subscriber-hider');
+        for (var i = 0; i < content.length; i++) {
+        content[i].classList.remove('subscriber-hider');
+    }
+}
+
+if (window.location.href.indexOf("ledevoir.com") !== -1) {
+        const counter = document.querySelector('.full.hidden-print.popup-msg');
+        removeDOMElement(counter);
+}
+
+if (window.location.href.indexOf("thehindu.com") !== -1) {
+        const paywall = document.getElementById('test');
+        removeDOMElement(paywall);
+}
 
 if (window.location.href.indexOf("nytimes.com") !== -1) {
     const preview_button = document.querySelector('.css-3s1ce0');
@@ -171,25 +181,35 @@ if (window.location.href.indexOf("nytimes.com") !== -1) {
             preview_button.click();
 }
 
-if (window.location.href.indexOf("caixinglobal.com") !== -1) {
-	const appContent = document.getElementById('appContent');
-	if (appContent) {
-		const p_hidden = document.querySelectorAll('p:not([style="display:block;"]');
-		for (var i = 0; i < p_hidden.length; i++) {
-			p_hidden[i].setAttribute('style', 'display:block;');
-		}
-	}
+if (window.location.href.indexOf("leparisien.fr") !== -1) {
+		window.removeEventListener('scroll', this.scrollListener);
+        const paywall = document.querySelector('.relative.piano-paywall.below_nav.sticky');
+        removeDOMElement(paywall);
+        setTimeout(function () {
+			var content = document.getElementsByClassName('content');
+			for (var i = 0; i < content.length; i++) {
+				content[i].removeAttribute("style");
+			}
+		}, 300); // Delay (in milliseconds)
 }
 
 function removeDOMElement(...elements) {
-	for (let element of elements) {
-		if (element) element.remove();
-	}
+    for (let element of elements) {
+        if (element)
+            element.remove();
+    }
+}
+
+function removeClassesByPrefix(el, prefix) {
+	for (var i = 0; i < el.classList.length; i++){
+        if (el.classList[i].startsWith(prefix)) {
+            el.classList.remove(el.classList[i]);
+        }
+    }
 }
 
 function pageContains(selector, text) {
 	let elements = document.querySelectorAll(selector);
-
 	return Array.prototype.filter.call(elements, function(element){
 		return RegExp(text).test(element.textContent);
 	});

--- a/contentScript.js
+++ b/contentScript.js
@@ -124,8 +124,9 @@ if (window.location.href.indexOf("firstthings.com") !== -1) {
 
 if (window.location.href.indexOf("bloomberg.com") !== -1) {
     document.addEventListener('DOMContentLoaded', () => {
-        const paywall = document.getElementById('paywall-banner');
-        removeDOMElement(paywall);
+		const fence = document.querySelector('.fence-body');
+		if (fence)
+			fence.classList.remove('fence-body');
     });
 }
 


### PR DESCRIPTION
Fix The Atlantic (cookie)
Fixes issue #394

Fix Bloomberg
Fixes issue #399

Fix Telegraaf.nl (timing issue)
Fix for persistent refreshing of paywall-banner.

Fix Ad.nl/Ed.nl (cookie)
Fix for new cookie-scheme (drop specific cookie).
Plus updates to old scripts in contentScript.js.