### PR TITLE
Fix The Atlantic & Bloomberg & Telegraaf.nl/Ad.nl/Ed.nl

### DIFF
--- a/background.js
+++ b/background.js
@@ -184,20 +184,17 @@ const remove_cookies = [
 
 // select specific cookie(s) to hold from remove_cookies domains
 const remove_cookies_select_hold = {
-	'.nrc.nl': ['nmt_closed_cookiebar'],
-	'.washingtonpost.com': ['wp_gdpr'],
-	'.wsj.com': ['wsjregion']
+	'nrc.nl': ['nmt_closed_cookiebar'],
+	'washingtonpost.com': ['wp_gdpr'],
+	'wsj.com': ['wsjregion']
 }
 
 // select only specific cookie(s) to drop from remove_cookies domains
 const remove_cookies_select_drop = {
-	'.ad.nl': ['temptationTrackingId'],
-	'.www.ad.nl': ['none'],
-	'www.ad.nl': ['none'],
-	'.ed.nl': ['temptationTrackingId'],
-	'.www.ed.nl': ['none'],
-	'www.ed.nl': ['none'],
-	'www.nrc.nl': ['counter']
+	'ad.nl': ['temptationTrackingId'],
+	'demorgen.be': ['TID_ID'],
+	'ed.nl': ['temptationTrackingId'],
+	'nrc.nl': ['counter']
 }
 
 // Override User-Agent with Googlebot
@@ -410,12 +407,13 @@ chrome.webRequest.onCompleted.addListener(function(details) {
     chrome.cookies.getAll({domain: domainVar}, function(cookies) {
 		for (var i=0; i<cookies.length; i++) {
 			var cookie_domain = cookies[i].domain;
+			var rc_domain = cookie_domain.replace(/^(\.?www\.|\.)/, '');
 			// hold specific cookie(s) from remove_cookies domains
-			if ((cookie_domain in remove_cookies_select_hold) && remove_cookies_select_hold[cookie_domain].includes(cookies[i].name)){
+			if ((rc_domain in remove_cookies_select_hold) && remove_cookies_select_hold[rc_domain].includes(cookies[i].name)){
 				continue; // don't remove specific cookie
 			}
 			// drop only specific cookie(s) from remove_cookies domains
-			if ((cookie_domain in remove_cookies_select_drop) && !(remove_cookies_select_drop[cookie_domain].includes(cookies[i].name))){
+			if ((rc_domain in remove_cookies_select_drop) && !(remove_cookies_select_drop[rc_domain].includes(cookies[i].name))){
 				continue; // only remove specific cookie
 			}
 			chrome.cookies.remove({url: (cookies[i].secure ? "https://" : "http://") + cookies[i].domain + cookies[i].path, name: cookies[i].name});

--- a/background.js
+++ b/background.js
@@ -140,6 +140,7 @@ const allow_cookies = [
 'the-american-interest.com',
 'theadvocate.com.au',
 'theage.com.au',
+'theatlantic.com',
 'theaustralian.com.au',
 'trouw.nl',
 'vn.nl',
@@ -175,6 +176,7 @@ const remove_cookies = [
 'telegraaf.nl',
 'theadvocate.com.au',
 'theage.com.au',
+'theatlantic.com',
 'vn.nl',
 'washingtonpost.com',
 'wsj.com'
@@ -189,6 +191,12 @@ const remove_cookies_select_hold = {
 
 // select only specific cookie(s) to drop from remove_cookies domains
 const remove_cookies_select_drop = {
+	'.ad.nl': ['temptationTrackingId'],
+	'.www.ad.nl': ['none'],
+	'www.ad.nl': ['none'],
+	'.ed.nl': ['temptationTrackingId'],
+	'.www.ed.nl': ['none'],
+	'www.ed.nl': ['none'],
 	'www.nrc.nl': ['counter']
 }
 
@@ -213,7 +221,6 @@ function setDefaultOptions() {
     chrome.tabs.create({ 'url': 'chrome://extensions/?options=' + chrome.runtime.id });
   });
 }
-
 
 var blockedRegexes = [
 /.+:\/\/.+\.tribdss\.com\//,

--- a/contentScript.js
+++ b/contentScript.js
@@ -18,27 +18,23 @@ if (location.hostname.endsWith('rep.repubblica.it')) {
 }
 
 if (window.location.href.indexOf("americanbanker.com") !== -1) {
-	const paywall = document.getElementsByClassName(
-		"embargo-content"
-	);
-	if (paywall && paywall.length > 0) {
-		paywall[0].className = "";
-	}
+	const paywall = document.getElementsByClassName('embargo-content')[0];
+	if (paywall)
+		paywall.classList.remove('embargo-content');
 }
 
 if (window.location.href.indexOf('telegraaf.nl') !== -1) {
-    const paywall = document.getElementById('TEMPRORARY_METERING_ID');
-    if (paywall) {
-        window.location.reload(1);
-    }
+	setTimeout(function () {
+		const paywall = document.getElementById('TEMPRORARY_METERING_ID');
+		if (paywall) {
+			window.location.reload(true);
+		}
+	}, 1000); // Delay (in milliseconds)
 }
 
-if (window.location.href.indexOf('ed.nl') !== -1) {
+if (window.location.href.indexOf('ad.nl') !== -1 || window.location.href.indexOf('ed.nl') !== -1) {
 	let paywall = document.querySelector('.article__component.article__component--paywall-module-notification');
-	if (paywall) {
-		paywall.remove();
-		paywall = null;
-	}
+	removeDOMElement(paywall);
 }
 
 if (window.location.href.indexOf("washingtonpost.com") !== -1) {
@@ -83,11 +79,8 @@ if (window.location.href.indexOf("mexiconewsdaily.com") !== -1) {
 }
 
 if (window.location.href.indexOf("the-american-interest.com") !== -1) {
-  const counter = document.getElementById('article-counter') || false;
-  if (counter) {
-	counter.remove();
-	counter = false; 
-  }
+  const counter = document.getElementById('article-counter');
+  removeDOMElement(counter);
 }
 
 if (window.location.href.indexOf("nzherald.co.nz") !== -1) {
@@ -117,15 +110,17 @@ if (window.location.href.indexOf("parool.nl") !== -1 || window.location.href.ind
 
 if (window.location.href.indexOf("firstthings.com") !== -1) {
     const paywall = document.getElementsByClassName('paywall')[0];
-
-  if (paywall)
-        removeDOMElement(paywall);
+	removeDOMElement(paywall);
 }
 
 if (window.location.href.indexOf("bloomberg.com") !== -1) {
     document.addEventListener('DOMContentLoaded', () => {
-        const paywall = document.getElementById('paywall-banner');
-        removeDOMElement(paywall);
+		const fence = document.querySelector('.fence-body');
+		if (fence){
+			fence.classList.remove('fence-body');
+		}
+		const paywall = document.getElementById('paywall-banner');
+		removeDOMElement(paywall);
     });
 }
 
@@ -138,7 +133,6 @@ if (window.location.href.indexOf("bloombergquint.com") !== -1) {
 if (window.location.href.indexOf("medium.com") !== -1) {
 	const bottomMessageText = 'Get one more story in your member preview when you sign up. It’s free.';
 	const DOMElementsToTextDiv = pageContains('div', bottomMessageText);
-
 	if (DOMElementsToTextDiv[2]) removeDOMElement(DOMElementsToTextDiv[2]);
 }
 
@@ -161,13 +155,10 @@ if (window.location.href.indexOf('lemonde.fr') !== -1) {
 }
 	
 if (window.location.href.indexOf("canberratimes.com.au") !== -1) {
-    
         const paywall = document.querySelector('.subscribe-article.news-article-body.article__body');
         paywall.classList.remove('subscribe-article');
-
         var subscribe = document.getElementsByClassName('subscriber-container')[0];
         removeDOMElement(subscribe);
-    
         var content = document.getElementsByClassName('subscriber-hider');
         for (var i = 0; i < content.length; i++) {
         content[i].classList.remove('subscriber-hider');
@@ -175,19 +166,16 @@ if (window.location.href.indexOf("canberratimes.com.au") !== -1) {
 }
 
 if (window.location.href.indexOf("ledevoir.com") !== -1) {
-
         const counter = document.querySelector('.full.hidden-print.popup-msg');
         removeDOMElement(counter);
 }
 
 if (window.location.href.indexOf("thehindu.com") !== -1) {
-  
-         const paywall = document.getElementById('test');
+        const paywall = document.getElementById('test');
         removeDOMElement(paywall);
 }
 
 if (window.location.href.indexOf("nytimes.com") !== -1) {
-
     const preview_button = document.querySelector('.css-3s1ce0');
         if (preview_button)
             preview_button.click();
@@ -195,10 +183,8 @@ if (window.location.href.indexOf("nytimes.com") !== -1) {
 
 if (window.location.href.indexOf("leparisien.fr") !== -1) {
 		window.removeEventListener('scroll', this.scrollListener);
-
         const paywall = document.querySelector('.relative.piano-paywall.below_nav.sticky');
         removeDOMElement(paywall);
-
         setTimeout(function () {
 			var content = document.getElementsByClassName('content');
 			for (var i = 0; i < content.length; i++) {
@@ -216,7 +202,7 @@ function removeDOMElement(...elements) {
 
 function removeClassesByPrefix(el, prefix) {
 	for (var i = 0; i < el.classList.length; i++){
-        if(el.classList[i].startsWith(prefix)) {
+        if (el.classList[i].startsWith(prefix)) {
             el.classList.remove(el.classList[i]);
         }
     }


### PR DESCRIPTION
Fix The Atlantic (cookie)
Fixes issue #394

Fix Bloomberg
Fixes issue #399

Fix Telegraaf.nl (timing issue)
Fix for persistent refreshing of paywall-banner.

Fix Ad.nl/Ed.nl (cookie)
Fix for new cookie-scheme (drop specific cookie).
Plus updates to old scripts in contentScript.js.

Simplify specific cookie drop/hold
Search for specific cookiename in all available cookie-(sub)domains.