### PR TITLE
Fix Businessinsider & SfChronicle & Economist & BizJournals

### DIFF
--- a/background.js
+++ b/background.js
@@ -299,7 +299,7 @@ chrome.webRequest.onBeforeRequest.addListener(function(details) {
   return {cancel: true}; 
   },
   {
-    urls: ["*://*.thestar.com/*", "*://*.theglobeandmail.com/*", "*://*.afr.com/*", "*://*.bizjournals.com/*", "*://*.bostonglobe.com/*"],
+    urls: ["*://*.thestar.com/*", "*://*.theglobeandmail.com/*", "*://*.afr.com/*", "*://*.bostonglobe.com/*", "*://*.tinypass.com/*"],
     types: ["script"]
   },
   ["blocking"]

--- a/background.js
+++ b/background.js
@@ -224,7 +224,8 @@ var blockedRegexes = {
 'thenation.com': /thenation\.com\/.+\/paywall-script\.php/,
 'haaretz.co.il': /haaretz\.co\.il\/htz\/js\/inter\.js/,
 'nzherald.co.nz': /nzherald\.co\.nz\/.+\/headjs\/.+\.js/,
-'businessinsider.com': /(.+\.tinypass\.com\/.+|cdn\.onesignal\.com\/sdks\/.+\.js)/
+'businessinsider.com': /(.+\.tinypass\.com\/.+|cdn\.onesignal\.com\/sdks\/.+\.js)/,
+'economist.com': /.+\.tinypass\.com\/.+/
 };
 
 const userAgentDesktop = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
@@ -298,7 +299,7 @@ chrome.webRequest.onBeforeRequest.addListener(function(details) {
   return {cancel: true}; 
   },
   {
-    urls: ["*://*.thestar.com/*", "*://*.economist.com/*", "*://*.theglobeandmail.com/*", "*://*.afr.com/*", "*://*.bizjournals.com/*", "*://*.bostonglobe.com/*"],
+    urls: ["*://*.thestar.com/*", "*://*.theglobeandmail.com/*", "*://*.afr.com/*", "*://*.bizjournals.com/*", "*://*.bostonglobe.com/*"],
     types: ["script"]
   },
   ["blocking"]

--- a/contentScript.js
+++ b/contentScript.js
@@ -200,6 +200,11 @@ if (window.location.href.indexOf("leparisien.fr") !== -1) {
 		}, 300); // Delay (in milliseconds)
 }
 
+if (window.location.href.indexOf("economist.com") !== -1) {
+  const wrapper = document.getElementById('bottom-page-wrapper');
+  removeDOMElement(wrapper);
+}
+
 function removeDOMElement(...elements) {
     for (let element of elements) {
         if (element)

--- a/contentScript.js
+++ b/contentScript.js
@@ -170,6 +170,11 @@ if (window.location.href.indexOf("ledevoir.com") !== -1) {
         removeDOMElement(counter);
 }
 
+if (window.location.href.includes('ft.com')) {
+    const cookie_banner = document.querySelector('.n-messaging-banner__outer');
+    removeDOMElement(cookie_banner);
+}
+
 if (window.location.href.indexOf("thehindu.com") !== -1) {
         const paywall = document.getElementById('test');
         removeDOMElement(paywall);

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,4 +1,11 @@
-window.localStorage.clear();
+var arr_localstorage_hold = ['sfchronicle.com'];
+var localstorage_hold = arr_localstorage_hold.some(function(url) {
+	return window.location.href.indexOf(url) !== -1;
+});
+
+if (!localstorage_hold){
+	window.localStorage.clear();
+}
 
 if (location.hostname.endsWith('rep.repubblica.it')) {
     if (location.href.includes('/pwa/')) {
@@ -168,11 +175,6 @@ if (window.location.href.indexOf("canberratimes.com.au") !== -1) {
 if (window.location.href.indexOf("ledevoir.com") !== -1) {
         const counter = document.querySelector('.full.hidden-print.popup-msg');
         removeDOMElement(counter);
-}
-
-if (window.location.href.includes('ft.com')) {
-    const cookie_banner = document.querySelector('.n-messaging-banner__outer');
-    removeDOMElement(cookie_banner);
 }
 
 if (window.location.href.indexOf("thehindu.com") !== -1) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -205,6 +205,18 @@ if (window.location.href.indexOf("economist.com") !== -1) {
   removeDOMElement(wrapper);
 }
 
+if (window.location.href.indexOf("bizjournals.com") !== -1) {
+		const sheet_overlay = document.querySelector('.sheet-overlay');
+		const chunk_paywall = document.querySelector('.chunk--paywall');
+		removeDOMElement(sheet_overlay, chunk_paywall);
+		const overlaid = document.querySelectorAll('.is-overlaid');
+		for (var i = 0; i < overlaid.length; i++) {
+			overlaid[i].classList.remove('is-overlaid');
+		}
+		const body_hidden = document.querySelector('.js-pre-chunks__story-body');
+		body_hidden.removeAttribute('style');
+}
+
 function removeDOMElement(...elements) {
     for (let element of elements) {
         if (element)

--- a/options.js
+++ b/options.js
@@ -5,7 +5,7 @@ var defaultSites = {
   'Barron\'s': 'barrons.com',
   'Bloomberg': 'bloomberg.com',
   'Bloomberg Quint': 'bloombergquint.com',
-  'Business Insider (javascript disabled)': 'businessinsider.com',
+  'Business Insider': 'businessinsider.com',
   'Crain\'s Chicago Business': 'chicagobusiness.com',
   'Chicago Tribune': 'chicagotribune.com',
   'Corriere Della Sera': 'corriere.it',

--- a/options.js
+++ b/options.js
@@ -71,7 +71,7 @@ var defaultSites = {
   'The Boston Globe (javascript disabled)': 'bostonglobe.com',
   'The Business Journals (javascript disabled)': 'bizjournals.com',
   'The Canberra Times': 'canberratimes.com.au',
-  'The Economist (javascript disabled)': 'economist.com',
+  'The Economist': 'economist.com',
   'The Globe and Mail (javascript disabled)': 'theglobeandmail.com',
   'The Hindu': 'thehindu.com',
   'The Irish Times': 'irishtimes.com',

--- a/options.js
+++ b/options.js
@@ -69,7 +69,7 @@ var defaultSites = {
   'The Australian': 'theaustralian.com.au',
   'The Australian Financial Review (javascript disabled)': 'afr.com',
   'The Boston Globe (javascript disabled)': 'bostonglobe.com',
-  'The Business Journals (javascript disabled)': 'bizjournals.com',
+  'The Business Journals': 'bizjournals.com',
   'The Canberra Times': 'canberratimes.com.au',
   'The Economist': 'economist.com',
   'The Globe and Mail (javascript disabled)': 'theglobeandmail.com',


### PR DESCRIPTION
Fix Businessinsider
General javascript-block blurs and hides pictures/videos.
New option to block external scripts on referring (enabled) domain.
Fixes issue #404
PS site stays enabled, but reset in options at next save (because of update in description).

Fix SfChronicle (reload loop)
Exclusion from localstorage.clear (contentScript.js).
Fixes issue #406

Fix Economist (only block external paywall-script)
PS site stays enabled, but reset in options at next save (because of update in description).

Fix BizJournals (no more Javascript-blocked necessary)
Fixes issue #358
PS site stays enabled, but reset in options at next save (because of update in description).