### PR TITLE
Fix WSJ/Foreign Policy (proper)/Philidelphia Inquirer

### DIFF
--- a/background.js
+++ b/background.js
@@ -244,7 +244,8 @@ var blockedRegexes = {
 'businessinsider.com': /(.+\.tinypass\.com\/.+|cdn\.onesignal\.com\/sdks\/.+\.js)/,
 'economist.com': /.+\.tinypass\.com\/.+/,
 'lrb.co.uk': /.+\.tinypass\.com\/.+/,
-'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/
+'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/,
+'foreignpolicy.com': /.+\.tinypass\.com\/.+/
 };
 
 const userAgentDesktop = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"

--- a/background.js
+++ b/background.js
@@ -245,7 +245,8 @@ var blockedRegexes = {
 'economist.com': /.+\.tinypass\.com\/.+/,
 'lrb.co.uk': /.+\.tinypass\.com\/.+/,
 'bostonglobe.com': /meter\.bostonglobe\.com\/js\/.+/,
-'foreignpolicy.com': /.+\.tinypass\.com\/.+/
+'foreignpolicy.com': /.+\.tinypass\.com\/.+/,
+'inquirer.com': /.+\.tinypass\.com\/.+/
 };
 
 const userAgentDesktop = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"

--- a/background.js
+++ b/background.js
@@ -191,13 +191,11 @@ const remove_cookies = [
 'vn.nl',
 'washingtonpost.com',
 'wired.com',
-'wsj.com'
 ]
 
 // select specific cookie(s) to hold from remove_cookies domains
 const remove_cookies_select_hold = {
-	'washingtonpost.com': ['wp_gdpr'],
-	'wsj.com': ['wsjregion']
+	'washingtonpost.com': ['wp_gdpr']
 }
 
 // select only specific cookie(s) to drop from remove_cookies domains


### PR DESCRIPTION
Fix WSJ (reformatting)
Maintain cookies to prevent reformatting at every new page.

Fix Foreign Policy (proper)
Block paywall-script which can also be blocked by uBlock Origin.
Fixes issue #428

Fix Philidelphia Inquirer
Block paywall-script which can also be blocked by uBlock Origin.