### PR TITLE
Add custom sites (remove cookies for free article limit)

### DIFF
--- a/background.js
+++ b/background.js
@@ -117,7 +117,7 @@ const restrictions = {
 }
 
 // Don't remove cookies before page load
-const allow_cookies = [
+var allow_cookies = [
 'ad.nl',
 'asia.nikkei.com',
 'bostonglobe.com',
@@ -161,7 +161,7 @@ const allow_cookies = [
 ]
 
 // Removes cookies after page load
-const remove_cookies = [
+var remove_cookies = [
 'ad.nl',
 'asia.nikkei.com',
 'bostonglobe.com',
@@ -267,6 +267,21 @@ chrome.storage.sync.get({
   enabledSites = Object.keys(items.sites).map(function(key) {
     return items.sites[key];
   });
+});
+
+var customSites = [];
+
+// Get the custom sites & add to allow/remove_cookies
+chrome.storage.sync.get({
+  sites_custom: {}
+}, function(items) {
+  var sites_custom = items.sites_custom;
+  customSites = Object.keys(items.sites_custom).map(function(key) {
+    return items.sites_custom[key];
+  });
+  customSites.shift(); // remove custom title
+  remove_cookies = remove_cookies.concat(customSites);
+  allow_cookies = allow_cookies.concat(customSites);
 });
 
 // Listen for changes to options

--- a/manifest.json
+++ b/manifest.json
@@ -21,5 +21,6 @@
 		"page": "options.html"
 	},
     "permissions": [ "cookies", "<all_urls>", "storage", "webRequest", "webRequestBlocking"],
+	"web_accessible_resources": ["sites_custom.json"],
 	"version": "1.6.1"
 }

--- a/options.js
+++ b/options.js
@@ -131,9 +131,22 @@ function save_options() {
   });
 }
 
+function renderOptions() {
+	const url_sites = chrome.runtime.getURL('sites_custom.json');
+	fetch(url_sites)
+		.then(res => res.json())
+		.then((json) => {var defaultSites_merge = {...defaultSites, ...json }; 
+							defaultSites = defaultSites_merge;
+							renderOptions_default();
+							chrome.storage.sync.set({
+								sites_custom: json
+							}, function() {});
+						} );
+}
+
 // Restores checkbox input states using the preferences
 // stored in chrome.storage.
-function renderOptions() {
+function renderOptions_default() {
   chrome.storage.sync.get({
     sites: {}
   }, function(items) {

--- a/sites_custom.json
+++ b/sites_custom.json
@@ -1,0 +1,8 @@
+{
+  "----- custom sites (remove cookies) -----": "",
+  "American Affairs": "americanaffairsjournal.org",
+  "Dark Reading": "darkreading.com",
+  "Pittsburgh Post Gazette": "post-gazette.com",
+  "The Sacramento Bee (free articles only)": "sacbee.com",
+  "Tubantia": "tubantia.nl"
+}


### PR DESCRIPTION
Read list of custom sites from local json-file (could also read from GitHub repository).
Sites which are less likely to end up in the main list of this extension (or less familiar sites currently in BP could also be transfered to this list).
These sites are loaded into BP options (by default disabled) and the allow_cookies/remove_cookies lists (background.js).
No more need to edit readme.md, background.js and options.js for these specific sites (just add line to sites_custom.json).

Proposal #445