### PR TITLE
Performance and bug fixing :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@
 [The Hindu](https://www.thehindu.com)\
 [The Irish Times](https://www.irishtimes.com)\
 [The Japan Times](https://www.japantimes.co.jp)\
+[The Kansas City Star](https://www.kansascity.com)\
 [The Mercury News](https://www.mercurynews.com)\
 [The Mercury Tasmania](https://www.themercury.com.au)\
 [The Morning Call](https://www.mcall.com)\

--- a/background.js
+++ b/background.js
@@ -20,7 +20,6 @@ const allow_cookies = [
 'economist.com',
 'ed.nl',
 'examiner.com.au',
-'fd.nl',
 'ft.com',
 'harpers.org',
 'hbr.org',
@@ -119,6 +118,7 @@ const remove_cookies_select_drop = {
   'demorgen.be': ['TID_ID'],
   'economist.com': ['rvuuid'],
   'ed.nl': ['temptationTrackingId'],
+  'fd.nl': ['socialread'],
   'nrc.nl': ['counter'],
 }
 
@@ -309,7 +309,7 @@ extension_api.webRequest.onBeforeSendHeaders.addListener(function(details) {
   }
 
   // remove cookies for sites medium platform (mainfest.json needs in permissions: <all_urls>)
-  if (isSiteEnabled({url: 'medium.com'}) && matchUrlDomain('cdn-client.medium.com', details.url) && !matchUrlDomain('medium.com', header_referer)) {
+  if (isSiteEnabled({url: 'https://medium.com'}) && matchUrlDomain('cdn-client.medium.com', details.url) && !matchUrlDomain('medium.com', header_referer)) {
     extension_api.cookies.getAll({domain: urlHost(header_referer)}, function(cookies) {
       for (var i=0; i<cookies.length; i++) {
         extension_api.cookies.remove({url: (cookies[i].secure ? "https://" : "http://") + cookies[i].domain + cookies[i].path, name: cookies[i].name});
@@ -357,7 +357,7 @@ extension_api.webRequest.onBeforeSendHeaders.addListener(function(details) {
     // this fixes images not being loaded on cooking.nytimes.com main page
     // referrer has to be *nytimes.com otherwise returns 403
     requestHeader.value = 'https://cooking.nytimes.com';
-  } else if (matchUrlDomain(['wsj.com', 'ft.com'], details.url)) {
+  } else if (matchUrlDomain(['wsj.com', 'ft.com', 'fd.nl'], details.url)) {
     requestHeader.value = 'https://www.facebook.com/';
   } else {
     requestHeader.value = 'https://www.google.com/';

--- a/background.js
+++ b/background.js
@@ -129,6 +129,7 @@ const use_google_bot = [
 'fd.nl',
 'haaretz.co.il',
 'haaretz.com',
+'kansascity.com',
 'lemonde.fr',
 'mexiconewsdaily.com',
 'nytimes.com',

--- a/common.js
+++ b/common.js
@@ -149,7 +149,9 @@ function matchDomain(domains, hostname) {
 function urlHost(url) {
     try {
         return new URL(url).hostname;
-    } catch(e) { e; }
+    } catch(e) {
+        console.log(`urlHost('${url}') fails: '${e}'`);
+    }
     return url;
 }
 

--- a/common.js
+++ b/common.js
@@ -1,4 +1,4 @@
-const extension_api =
+var extension_api =
     (typeof browser === 'object' &&
      typeof browser.runtime === 'object' &&
      typeof browser.runtime.getManifest === 'function') ? browser :
@@ -8,7 +8,7 @@ const extension_api =
     console.log('Cannot find extension_api under namespace "browser" or "chrome"');
 
 // Cookies from this list are blocked by default
-const defaultSites = {
+var defaultSites = {
     'Adweek': 'adweek.com',
     'Algemeen Dagblad': 'ad.nl',
     'American Banker': 'americanbanker.com',
@@ -135,3 +135,24 @@ const defaultSites = {
     'Wired': 'wired.com',
     '*General Paywall Bypass*': 'generalpaywallbypass',
 };
+
+function matchDomain(domains, hostname) {
+    var matched_domain = false;
+    if (!hostname)
+        hostname = window.location.hostname;
+    if (typeof domains === 'string')
+        domains = [domains];
+    domains.some(domain => (hostname === domain || hostname.endsWith('.' + domain)) && (matched_domain = domain));
+    return matched_domain;
+}
+
+function urlHost(url) {
+    try {
+        return new URL(url).hostname;
+    } catch(e) { e; }
+    return url;
+}
+
+function matchUrlDomain(domains, url) {
+    return matchDomain(domains, urlHost(url));
+}

--- a/common.js
+++ b/common.js
@@ -107,6 +107,7 @@ var defaultSites = {
     'The Hindu': 'thehindu.com',
     'The Irish Times (free articles only)': 'irishtimes.com',
     'The Japan Times': 'japantimes.co.jp',
+    'The Kansas City Star': 'kansascity.com',
     'TheMarker': 'themarker.com',
     'The Mercury News': 'mercurynews.com',
     'The Mercury Tasmania': 'themercury.com.au',

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,7 +1,5 @@
 var arr_localstorage_hold = ['sfchronicle.com', 'cen.acs.org'];
-var localstorage_hold = arr_localstorage_hold.some(function(url) {
-    return window.location.href.indexOf(url) !== -1;
-});
+var localstorage_hold = matchDomain(arr_localstorage_hold);
 
 if (!localstorage_hold){
     window.localStorage.clear();
@@ -156,8 +154,7 @@ if (matchDomain('afr.com')) {
     document.addEventListener('DOMContentLoaded', () => {
         const hidden_image = document.querySelectorAll('img');
         for (let i = 0; i < hidden_image.length; i++) {
-            var src = hidden_image[i].src;
-            if ('src: ' + src.indexOf(".gif") !== -1) {
+            if (hidden_image[i].src.includes('.gif')) {
                 var data_src = hidden_image[i].getAttribute("data-src");
                 if (data_src)
                     hidden_image[i].setAttribute('src', data_src);
@@ -233,8 +230,7 @@ if (matchDomain('theglobeandmail.com')) {
         }
         const hidden_image = document.querySelectorAll('img');
         for (let i = 0; i < hidden_image.length; i++) {
-            var src = hidden_image[i].src;
-            if (src.indexOf("data:image/gif") !== -1) {
+            if (hidden_image[i].src.includes('data:image/gif')) {
                 var data_src = hidden_image[i].getAttribute("data-src");
                 if (data_src)
                     hidden_image[i].setAttribute('src', data_src);
@@ -400,13 +396,6 @@ if (matchDomain('techinasia.com')) {
     const splash_subscribe = document.querySelector('.splash-subscribe');
     const paywall_hard = document.querySelector('.paywall-hard');
     removeDOMElement(splash_subscribe, paywall_hard);
-}
-
-function matchDomain(domains) {
-    var hostname = window.location.hostname;
-    if (typeof domains === 'string')
-        domains = [domains];
-    return domains.some(domain => hostname === domain || hostname.endsWith('.' + domain));
 }
 
 function removeDOMElement(...elements) {

--- a/contentScript.js
+++ b/contentScript.js
@@ -7,9 +7,10 @@ if (!localstorage_hold){
 
 if (matchDomain('rep.repubblica.it')) {
     if (window.location.href.includes('/pwa/')) {
-        window.location.href = window.location.href.replace('/pwa/', '/ws/detail/');
+        setTimeout(function () {
+            window.location.href = window.location.href.replace('/pwa/', '/ws/detail/');
+        }, 400);
     }
-
     if (window.location.href.includes('/ws/detail/')) {
         const paywall = document.querySelector('.paywall[subscriptions-section="content"]');
         if (paywall) {
@@ -281,13 +282,18 @@ if (matchDomain('canberratimes.com.au')) {
     }
 }
 
+if (matchDomain('asia.nikkei.com')) {
+    const cookie_banner = document.querySelector('.pw-widget');
+    removeDOMElement(cookie_banner);
+}
+
 if (matchDomain('ledevoir.com')) {
         const counter = document.querySelector('.full.hidden-print.popup-msg');
         removeDOMElement(counter);
 }
 
 if (matchDomain('ft.com')) {
-    const cookie_banner = document.querySelector('.n-messaging-banner__outer');
+    const cookie_banner = document.querySelector('.cookie-banner');
     removeDOMElement(cookie_banner);
 }
 

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -50,7 +50,7 @@
     "*://*.washingtonpost.com/*",
     "*://*.wsj.com/*"
     ],
-      "js": ["contentScript.js"]
+      "js": ["common.js", "contentScript.js"]
     }
   ],
   "applications": {


### PR DESCRIPTION
I went looking for what was wrong with wsj.com, found so many issues,
this happened.  wsj.com works for me now on both Opera & Firefox.

- manifest-ff.json: add common.js to content script list
- contentScript, common.js: move matchDomain() from content to common
- common.js: make extension_api & defaultSites 'var' to fix redefinition errors on FF
- common.js: matchDomain() take an optional hostname (vs location.hostname)
- common.js: add urlHost() to extract hostname from URL
- common.js: add matchUrlDomain() to work on URLs (not appropriate on all calls)
- background.js: use matchUrlDomain() where appropriate
- background.js: string.includes() in place of indexOf() where appropriate
- background.js: check expensive isSiteEnabled() after cheap string compares
- background.js: check isSiteEnabled() *before* complex stuff that will abort anyway
- background.js: parse through entire requestHeaders[] fewer times
- background.js: no need to call handlerBehaviorChanged()
- background.js: inject common.js before contentScript.js, which now needs it