### PR TITLE
Updated the filter for Washington Posts

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -88,6 +88,42 @@ if (matchDomain('washingtonpost.com')) {
             }
         }, 300); // Delay (in milliseconds)
     }
+
+    // the paywall doesn't appear immediately, so we do a couple attempts to kill it after initializetion
+    var attempts = 0;
+    var func = function(){
+        return function(){
+            try {
+                if(attempts++ > 10) return;
+
+                // Guys from WP assign a random class to the paywall block, we can get around this using the visible content search.
+                var xpath = '//h3[text()="We noticed you\'re blocking ads."]';
+                var matchingElement = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+                var bodyEl = document.getElementsByTagName('body')[0];
+                while(matchingElement != null &&
+                    matchingElement.parentElement != null &&
+                    matchingElement.parentElement != bodyEl) {
+                    matchingElement = matchingElement.parentElement;
+                }
+
+                if (matchingElement) {
+                    matchingElement.remove();
+                    
+                    // Make an article scrollable
+                    const htmlEl = document.getElementsByTagName('html')[0];
+                    if(htmlEl){
+                        htmlEl.style.overflow = 'scroll';
+                    }
+                } else {
+                    setTimeout(func(), 500); 
+                }
+            } catch (error) {
+                console.error('Something went wrong, please see exception details', error);
+            }
+        }   
+    }
+
+    setTimeout(func(), 500);
 }
 
 if (matchDomain('wsj.com')) {


### PR DESCRIPTION
WashingtonPosts introduce a version of a paywall when a class it is
marked with is autogenerated. It's quite difficult to find the paywall
block using regular CSS.

To get around this problem xpath should fit pretty well. See the link
to the SO answer below.

However, it's not enough to remove the paywall block, since they
also make the page itself not scrollable by assigning overflow
attribute to the html node. We need to replace hidden by fix.

To make sure that paywall isn't removed, WashingtonPost website
doesn't display the wall for some time (maybe it takes some time to load).
That's why we have to try several times until the wall appears.
I used 10 attempts 500ms, it should give us 5s to block the wall.

SO xpath answer: https://stackoverflow.com/a/29289196/2632860