### PR TITLE
Add support for investig.com

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -21,6 +21,7 @@ const allow_cookies = [
 'ft.com',
 'harpers.org',
 'hbr.org',
+'investing.com',
 'lesechos.fr',
 'lrb.co.uk',
 'medium.com',

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -424,6 +424,15 @@ if (matchDomain('thewrap.com')) {
     }
 }
 
+if (window.location.href.indexOf("investing.com") !== -1) {
+    setTimeout(function () {
+        const paywall = document.querySelector('#abPopup');
+
+        removeDOMElement(paywall);
+        document.body.removeAttribute('style');
+    }, 500); // Delay (in milliseconds)
+}
+
 function matchDomain(domains) {
     var hostname = window.location.hostname;
     if (typeof domains === 'string')

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -40,6 +40,7 @@ const defaultSites = {
     'Herald Sun': 'heraldsun.com.au',
     'Het Financieele Dagblad': 'fd.nl',
     'Inc.com': 'inc.com',
+    'Investing.com': 'investing.com',
     'Investors Chronicle': 'investorschronicle.co.uk',
     'La Nacion': 'lanacion.com.ar',
     'La Repubblica': 'repubblica.it',


### PR DESCRIPTION
#579 Add support for investing.com ad-block wall.

I've tested manually, it briefly shows the ad-block wall, but then it disappear.

I've tested that I was able to login in the site using Google authentication with and without the cookie options for this site.

I haven't tried the other ones: Facebook and user/passwd.