### PR TITLE
Add exception for economist.com graphics rendering script

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -173,6 +173,11 @@ const blockedRegexes = {
   'thewrap.com': /thewrap\.com\/.+\/wallkit\.js/
 };
 
+// Allowed external scripts
+const allowedRegexes = {
+  'economist.com': /infographics.economist.com\/utils\/ai2html-resizer.*\.js/
+};
+
 const userAgentDesktop = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
 const userAgentMobile = 'Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible ; Googlebot/2.1 ; +http://www.google.com/bot.html)';
 
@@ -230,6 +235,12 @@ function getBadgeText (currentUrl) {
 extensionApi.webRequest.onBeforeRequest.addListener(function (details) {
   if (!isSiteEnabled(details) && !enabledSites.includes('generalpaywallbypass')) {
     return;
+  }
+  // Don't block allowed scripts
+  for (const domain in allowedRegexes) {
+    if (isSameDomain(details.url, domain) && details.url.match(allowedRegexes[domain])) {
+      return;
+    }
   }
   return { cancel: true };
 },


### PR DESCRIPTION
Hi @iamadamdev!

I've noticed that graphs are not being rendered on economist.com.

Example:
![image](https://user-images.githubusercontent.com/461133/81983277-66c66d00-9633-11ea-85b8-1ae68276a899.png)
`https://www.economist.com/graphic-detail/2020/05/16/phone-data-identify-travel-hubs-at-risk-of-a-second-wave-of-infections`

This is because all scripts are being blocked, including one that renders .ai files to HTML (`https://infographics.economist.com/utils/ai2html-resizer-v7-econ.js`).

This PR adds a whitelist for scripts that is checked before blocking all scripts in a website.

Thanks! 