### PR TITLE
Nullity check in storage.onChanged

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -194,7 +194,7 @@ extensionApi.storage.sync.get({
 
 // Listen for changes to options
 extensionApi.storage.onChanged.addListener(function (changes, namespace) {
-  if (changes.sites) {
+  if (changes.sites && changes.sites.newValue) {
     const sites = changes.sites.newValue;
     enabledSites = Object.values(sites);
   }


### PR DESCRIPTION
`newValue` is optional, so it could be null. See document: https://developer.chrome.com/extensions/storage#type-StorageChange