### PR TITLE
Fix paywall removal on telegraph.co.uk by blocking martech script

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -166,6 +166,7 @@ const blockedRegexes = {
   'repubblica.it': /scripts\.repubblica\.it\/pw\/pw\.js.+/,
   'spectator.co.uk': /.+\.tinypass\.com\/.+/,
   'spectator.com.au': /.+\.tinypass\.com\/.+/,
+  'telegraph.co.uk': /.+telegraph\.co\.uk.+martech.+/,
   'thecourier.com.au': /.+cdn-au\.piano\.io\/api\/tinypass.+\.js/,
   'theglobeandmail.com': /theglobeandmail\.com\/pb\/resources\/scripts\/build\/chunk-bootstraps\/.+\.js/,
   'thenation.com': /thenation\.com\/.+\/paywall-script\.php/,


### PR DESCRIPTION
Paywall changed on [telegraph.co.uk](https://telegraph.co.uk/), this PR fixes the bypass by blocking scripts under `/martech/`.