### PR TITLE
support adding custom sites

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
   "update_url": "https://raw.githubusercontent.com/iamadamdev/bypass-paywalls-chrome/master/src/updates/updates.xml",
   "short_name": "Bypass Paywall",
   "options_ui": {
-    "chrome_style": true,
+    "chrome_style": false,
     "page": "src/html/options.html"
   },
   "permissions": [

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -4,35 +4,124 @@
   <meta charset="utf-8">
   <title>Bypass Paywalls Options</title>
   <style>
+    body {
+      width:350px;
+
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+    }
+
     #bypass_sites label {
       display: block;
     }
-    body {
-      width:350px;
-      height:600px;
+
+    #tabs {
+      display: flex;
+      background-color: #ccc;
+    }
+    #tabs button {
+      flex-grow: 1;
+      background: #ddd;
+      text-shadow: none;
+      margin: 0;
+      padding: 0;
+      border: none;
+      padding-bottom: 3px;
+      border-bottom: 1px solid #666;
+      border-right: solid 1px #ccc;
+      border-radius: 0;
+    }
+    #tabs button:last-of-type {
+      border-right: none;
+    }
+    #tabs button.active {
+      background-color: #fff;
+      color: black;
+      padding-bottom: 0;
+      border-bottom: solid blue 4px;
+    }
+
+    .pane {
+      height: 450px;
+      display: none;
+      flex-direction: column;
+    }
+
+    p {
+      margin: 0;
+      padding: .5em 0;
+      line-height: 1.3em;
+    }
+
+    #select-all {
+      border-top: solid 1px #aaa;
+      background: #eee;
+      padding: 4px 0;
+    }
+
+    #bypass_sites {
+      border-bottom: solid 1px #aaa;
+      flex-grow: 1;
+      overflow-y: auto;
+    }
+
+    input[type=checkbox] {
+      margin: 0 .5em;
+    }
+
+    .pane, #controls {
+      padding: 0 1em;
+    }
+
+    #controls {
+      align-self: flex-end;
+      padding: 1em;
+    }
+
+    .pane.active {
+      display: flex;
+    }
+
+    #custom textarea {
+      flex-grow: 1;
     }
   </style>
 </head>
 <body>
-  <div>
-    Selected sites will have their cookies cleared and referer set to Google. You should
-    uncheck sites you are logged in to otherwise you will be logged out on every visit.
+  <div id="tabs">
+    <button data-pane="sites">Supported Sites</button>
+    <button data-pane="custom">Other Sites</button>
   </div>
-  <br/>
-  <div id='bypass_sites'>
+
+  <div id="sites" class="pane">
+    <p>
+      Selected sites will have their cookies cleared and referer set to Google. You should
+      uncheck sites you are logged in to otherwise you will be logged out on every visit.
+    </p>
+    <label id="select-all"><input checked type="checkbox"><em>Select all/none</em></label>
+    <div id='bypass_sites'></div>
   </div>
-  <br/>
-  <div id="status"></div>
-  <div id="error"></div>
-  <br/>
-  <span style='float:left;'>
+
+  <div id="custom" class="pane">
+    <p>
+      To try bypassing other sites, enter domain names here (one domain per line).
+    </p>
+    <p>
+    <span style="color: #900; font-weight: bold">This feature is provided "as
+      is", and will not work with many sites.</span>
+    Please do not report issues with sites entered here.  Support for new sites
+    is not being added at this time and requests for support will be ignored.
+    </p>
+    <textarea id="custom_sites" placeholder="e.g.&#10;dailybeast.com&#10;quohogherald.com&#10;blagdonbugle.com&#10;etc..." /></textarea>
+  </div>
+
+  <div id="controls">
+    <div id="status"></div>
     <button id="save">Save</button>
-  </span>
-  <span style='float:right;'>
-    <button id="select-all">Select all</button>
-    <button id="select-none">Select none</button>
-  </span>
-  <br/><br/>
+  </div>
+
   <script src="../js/common.js"></script>
   <script src="../js/sites.js"></script>
   <script src="../js/options.js"></script>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -4,12 +4,18 @@
   <meta charset="utf-8">
   <title>Bypass Paywalls Options</title>
   <style>
+    html {
+      min-width: 350px;
+      max-width: 400px;
+    }
     body {
       min-width: 350px;
+      max-width: 400px;
       margin: 0;
       padding: 0;
       display: flex;
       flex-direction: column;
+      font-family: sans-serif;
     }
 
     #bypass_sites label {

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -97,6 +97,11 @@
     body.customSitesEnabled #tabs {
       display: flex;
     }
+
+    #status {
+      display: inline-block;
+      margin-right: 1em;
+    }
   </style>
 </head>
 <body>

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -5,8 +5,7 @@
   <title>Bypass Paywalls Options</title>
   <style>
     body {
-      width:350px;
-
+      min-width: 350px;
       margin: 0;
       padding: 0;
       display: flex;
@@ -18,7 +17,7 @@
     }
 
     #tabs {
-      display: flex;
+      display: none;
       background-color: #ccc;
     }
     #tabs button {
@@ -65,6 +64,7 @@
       border-bottom: solid 1px #aaa;
       flex-grow: 1;
       overflow-y: auto;
+      padding-bottom: 4px;
     }
 
     input[type=checkbox] {
@@ -87,12 +87,16 @@
     #custom textarea {
       flex-grow: 1;
     }
+
+    body.customSitesEnabled #tabs {
+      display: flex;
+    }
   </style>
 </head>
 <body>
   <div id="tabs">
     <button data-pane="sites">Supported Sites</button>
-    <button data-pane="custom">Other Sites</button>
+    <button data-pane="custom">Custom Sites</button>
   </div>
 
   <div id="sites" class="pane">

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -116,7 +116,7 @@ const removeCookiesSelectDrop = {
 };
 
 // Override User-Agent with Googlebot
-const useGoogleBotSites = [
+let useGoogleBotSites = [
   'adelaidenow.com.au',
   'barrons.com',
   'couriermail.com.au',
@@ -188,6 +188,10 @@ extensionApi.storage.sync.get({
   customSites: []
 }, function (items) {
   enabledSites = Object.values(items.sites).concat(items.customSites);
+
+  // Use googlebot UA for custom sites
+  useGoogleBotSites = useGoogleBotSites.concat(items.customSites).sort();
+
   if (extensionApi === chrome) {
     initGA();
   }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -141,6 +141,9 @@ let useGoogleBotSites = [
   'kansascity.com'
 ];
 
+// Contains google bot sites, above, plus any custom sitesk
+let _useGoogleBotSites = useGoogleBotSites;
+
 function setDefaultOptions () {
   extensionApi.storage.sync.set({
     sites: defaultSites
@@ -190,7 +193,7 @@ extensionApi.storage.sync.get({
   enabledSites = Object.values(items.sites).concat(items.customSites);
 
   // Use googlebot UA for custom sites
-  useGoogleBotSites = useGoogleBotSites.concat(items.customSites).sort();
+  _useGoogleBotSites = useGoogleBotSites.concat(items.customSites);
 
   if (extensionApi === chrome) {
     initGA();
@@ -323,7 +326,7 @@ extensionApi.webRequest.onBeforeSendHeaders.addListener(function (details) {
   }
 
   // override User-Agent to use Googlebot
-  const useGoogleBot = useGoogleBotSites.some(function (item) {
+  const useGoogleBot = _useGoogleBotSites.some(function (item) {
     return typeof item === 'string' && isSameDomain(details.url, item);
   });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -141,7 +141,7 @@ let useGoogleBotSites = [
   'kansascity.com'
 ];
 
-// Contains google bot sites, above, plus any custom sitesk
+// Contains google bot sites, above, plus any custom sites
 let _useGoogleBotSites = useGoogleBotSites;
 
 function setDefaultOptions () {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -184,9 +184,10 @@ let enabledSites = [];
 
 // Get the enabled sites
 extensionApi.storage.sync.get({
-  sites: {}
+  sites: {},
+  customSites: []
 }, function (items) {
-  enabledSites = Object.values(items.sites);
+  enabledSites = Object.values(items.sites).concat(items.customSites);
   if (extensionApi === chrome) {
     initGA();
   }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -5,18 +5,18 @@ function $(sel, el = document) {
 
 // Shortcut for document.querySelectorAll()
 function $$(sel, el = document) {
-  return [...el.querySelectorAll(sel)];
+  return Array.from(el.querySelectorAll(sel));
 }
 
 // Select UI pane
-function selectPane() {
+function selectPane(e) {
   const panes = $$('.pane');
   for (const tab of $$('#tabs button')) {
-    tab.classList.toggle('active', tab == this);
+    tab.classList.toggle('active', tab == e.target);
   }
 
   for (const pane of panes) {
-    pane.classList.toggle('active', pane.id == this.dataset.pane);
+    pane.classList.toggle('active', pane.id == e.target.dataset.pane);
   }
 }
 
@@ -105,7 +105,7 @@ function init() {
     el.addEventListener('click', selectPane);
   }
 
-  selectPane.apply($('#tabs button:first-child'));
+  selectPane({target: $('#tabs button:first-child')});
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -1,11 +1,14 @@
+// Shortcut for document.querySelector()
 function $(sel, el = document) {
   return el.querySelector(sel);
 }
 
+// Shortcut for document.querySelectorAll()
 function $$(sel, el = document) {
   return [...el.querySelectorAll(sel)];
 }
 
+// Select UI pane
 function selectPane() {
   const panes = $$('.pane');
   for (const tab of $$('#tabs button')) {
@@ -54,6 +57,7 @@ function renderOptions () {
     sites: {},
     customSites: [],
   }, function (items) {
+    // Render supported sites
     const sites = items.sites;
     for (const key in defaultSites) {
       if (!Object.prototype.hasOwnProperty.call(defaultSites, key)) {
@@ -73,17 +77,20 @@ function renderOptions () {
       $('#bypass_sites').appendChild(labelEl);
     }
 
+    // Render custom sites
     const customSites = items.customSites;
     $('#custom_sites').value = customSites.join('\n');
   });
 }
 
+// Select/deselect all supported sites
 function selectAll () {
   for (const el of $$('input')) {
     el.checked = this.checked;
   };
 }
 
+// Initialize UI
 function init() {
   renderOptions();
 

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -105,6 +105,10 @@ function init() {
   }
 
   selectPane({target: $('#tabs button:first-child')});
+
+  if (extensionApi === chrome) {
+    document.body.classList.add('customSitesEnabled');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -41,7 +41,7 @@ function saveOptions () {
   }, function () {
     // Update status to let user know options were saved.
     const status = $('#status');
-    status.textContent = 'Options saved.';
+    status.textContent = 'Options saved';
     setTimeout(function () {
       status.textContent = '';
 
@@ -49,7 +49,7 @@ function saveOptions () {
       chrome.runtime.reload();
 
       window.close();
-    }, 800);
+    }, 1200);
   });
 }
 
@@ -83,12 +83,19 @@ function renderOptions () {
     // Render custom sites
     const customSites = items.customSites;
     $('#custom_sites').value = customSites.join('\n');
+
+    // Set select all/none checkbox state.  Ideally we'd use the "indeterminate"
+    // state here, but that doesn't seem to be working this context.  See
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1097489
+    const nItems = $$('input[data-key]').length;
+    const nChecked = $$('input[data-key]').filter(el => el.checked).length;
+    $('#select-all input').checked = nChecked / nItems > 0.5;
   });
 }
 
 // Select/deselect all supported sites
 function selectAll () {
-  for (const el of $$('input')) {
+  for (const el of $$('input[data-key]')) {
     el.checked = this.checked;
   };
 }

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -34,7 +34,6 @@ function saveOptions () {
     .split('\n')
     .map(s => s.trim())
     .filter(s => s);
-  console.log('customSites', customSites);
 
   extensionApi.storage.sync.set({
     sites: sites,

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -45,6 +45,10 @@ function saveOptions () {
     status.textContent = 'Options saved.';
     setTimeout(function () {
       status.textContent = '';
+
+      // Reload runtime so background script picks up changes
+      chrome.runtime.reload();
+
       window.close();
     }, 800);
   });

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -84,12 +84,13 @@ function renderOptions () {
     const customSites = items.customSites;
     $('#custom_sites').value = customSites.join('\n');
 
-    // Set select all/none checkbox state.  Ideally we'd use the "indeterminate"
-    // state here, but that doesn't seem to be working this context.  See
+    // Set select all/none checkbox state.  Note: "indeterminate" checkboxes
+    // require `chrome_style: false` be set in manifest.json.  See
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1097489
     const nItems = $$('input[data-key]').length;
     const nChecked = $$('input[data-key]').filter(el => el.checked).length;
     $('#select-all input').checked = nChecked / nItems > 0.5;
+    $('#select-all input').indeterminate = nChecked && nChecked != nItems;
   });
 }
 


### PR DESCRIPTION
----

Allow users to enter a list of custom domain names that get basic bypass behavior (set referrer, remove cookies), as suggested in #654.

This reworks the options UI into two tabs:
* "Supported Sites" - The existing options UI ("Select All"/"Select None" became checkbox at top of list)
* "Other Sites" - New UI for entering custom domain names, along with a disclaimer about other sites not being supported.

Also includes tweaks for CSS flexbox style for cleaner layout and markup.  See screenshots, below.

----

![image](https://user-images.githubusercontent.com/164050/82837932-75a4ef00-9e7f-11ea-9fb2-a5fd059334d3.png)

![image](https://user-images.githubusercontent.com/164050/82845287-c37a2100-9e98-11ea-8396-42e311ce7050.png)
