### PR TITLE
Fix undefined error after browsing devtools

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -350,7 +350,7 @@ extensionApi.webRequest.onBeforeSendHeaders.addListener(function (details) {
   if (tabId !== -1) {
     extensionApi.tabs.get(tabId, function (currentTab) {
       // Validate url of current tab to avoid injecting script to unrelated sites
-      if (currentTab && isSiteEnabled(currentTab)) {
+      if (currentTab && currentTab.url && isSiteEnabled(currentTab)) {
         // run contentScript inside tab
         extensionApi.tabs.executeScript(tabId, {
           file: 'src/js/contentScript.js',


### PR DESCRIPTION
Devtool is actually a tab instance without URL. That's why this error happened

![image](https://user-images.githubusercontent.com/36013816/83086704-599e7a80-a044-11ea-98fe-7ebec31620d4.png)