### PR TITLE
Add apple daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 [Adweek](https://www.adweek.com)\
 [Algemeen Dagblad](https://www.ad.nl)\
 [American Banker](https://www.americanbanker.com)\
+[Apple Daily](https://hk.appledaily.com/)\
 [Baltimore Sun](https://www.baltimoresun.com)\
 [Barron's](https://www.barrons.com)\
 [Bloomberg Quint](https://www.bloombergquint.com)\

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -12,6 +12,7 @@
     "*://*.ad.nl/*",
     "*://*.afr.com/*",
     "*://*.americanbanker.com/*",
+    "*://*.appledaily.com/*",
     "*://*.bizjournals.com/*",
     "*://*.bloomberg.com/*",
     "*://*.bloombergquint.com/*",

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -21,6 +21,12 @@ if (matchDomain('rep.repubblica.it')) {
 } else if (matchDomain('americanbanker.com')) {
   const paywall = document.getElementsByClassName('embargo-content')[0];
   if (paywall) { paywall.classList.remove('embargo-content'); }
+} else if (matchDomain('appledaily.com')) {
+  const paywall = document.querySelector('.hk-paywall-container');
+  if (paywall) {
+    removeDOMElement(paywall);
+    document.getElementById("articleBody").style.height = "100%";
+  }
 } else if (matchDomain('telegraaf.nl')) {
   if (window.location.href.startsWith('https://www.telegraaf.nl/error?ref=/')) {
     window.location.href = window.location.href.split('&')[0].replace('error?ref=/', '');

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -25,7 +25,9 @@ if (matchDomain('rep.repubblica.it')) {
   const paywall = document.querySelector('.hk-paywall-container');
   if (paywall) {
     removeDOMElement(paywall);
-    document.getElementById("articleBody").style.height = "100%";
+    setTimeout(function () {
+      document.getElementById("articleBody").style.height = "100%";
+    }, 1000);
   }
 } else if (matchDomain('telegraaf.nl')) {
   if (window.location.href.startsWith('https://www.telegraaf.nl/error?ref=/')) {

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -3,6 +3,7 @@ const defaultSites = {
   'Adweek': 'adweek.com',
   'Algemeen Dagblad': 'ad.nl',
   'American Banker': 'americanbanker.com',
+  'Apple Daily': 'appledaily.com',
   'Baltimore Sun': 'baltimoresun.com',
   'Barron\'s': 'barrons.com',
   'Bloomberg': 'bloomberg.com',


### PR DESCRIPTION
- As titled, suggest to add [**Apple Daily**,](https://hk.appledaily.com/) a popular newspaper site in Hong Kong / Taiwan.