### PR TITLE
Proper automatic "last release" linking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 1. Drag the `bypass-paywalls-chrome-master` folder anywhere on the page to import it (do not delete the folder afterwards).
 
 **Mozilla Firefox**
-* [Download and install the latest version](https://github.com/iamadamdev/bypass-paywalls-chrome/releases/download/v1.7.3/bypass-paywalls-firefox.xpi)
+* [Download and install the latest version](https://github.com/iamadamdev/bypass-paywalls-chrome/releases/latest/download/bypass-paywalls-firefox.xpi)
 
 **Notes**
 * Every time you open Chrome it may warn you about running extensions in developer mode, just click 🗙 to keep the extension enabled.


### PR DESCRIPTION
https://help.github.com/en/github/administering-a-repository/linking-to-releases
Now, no need to update the Firefox add-on link in the README.md. It will always grab the latest.fxi release file, as long as it keeps the `bypass-paywalls-firefox.xpi` naming.
![20200616_174544](https://user-images.githubusercontent.com/13170204/84797070-ed7eb900-afe8-11ea-88f6-03d970687a3e.png)
