### PR TITLE
Added Financialpost.com under one PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 [Estadão](https://www.estadao.com.br)\
 [Examiner](https://www.examiner.com.au)\
 [Financial News](https://www.fnlondon.com)\
+[Financial Post](https://www.financialpost.com)\
 [Financial Times](https://www.ft.com)\
 [First Things](https://www.firstthings.com)\
 [Foreign Policy](https://www.foreignpolicy.com)\

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -56,6 +56,7 @@
     "*://*.washingtonpost.com/*",
     "*://*.wsj.com/*",
     "*://*.hbr.org/*"
+    "*://*.financialpost.com/*"
     ],
       "js": ["src/js/contentScript.js"]
     }
@@ -235,6 +236,8 @@
     "*://*.netdna-ssl.com/*",
     "*://*.startribune.com/*",
     "*://*.df.cl/*"
+    "*://*.financialpost.com/*"
+    
   ],
   "version": "1.7.6"
 }

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -237,7 +237,6 @@
     "*://*.startribune.com/*",
     "*://*.df.cl/*"
     "*://*.financialpost.com/*"
-    
   ],
   "version": "1.7.6"
 }

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -55,7 +55,7 @@
     "*://*.volkskrant.nl/*",
     "*://*.washingtonpost.com/*",
     "*://*.wsj.com/*",
-    "*://*.hbr.org/*"
+    "*://*.hbr.org/*",
     "*://*.financialpost.com/*"
     ],
       "js": ["src/js/contentScript.js"]

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -56,6 +56,7 @@ const allowCookies = [
   'nzz.ch',
   'handelsblatt.com',
   'thehindu.com'
+  'financialpost.com'
 ];
 
 // Removes cookies after page load

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -30,6 +30,7 @@ const defaultSites = {
   'Estadão': 'estadao.com.br',
   'Examiner': 'examiner.com.au',
   'Financial News': 'fnlondon.com',
+  'Financial Post':'financialpost.com',
   'Financial Times': 'ft.com',
   'First Things': 'firstthings.com',
   'Foreign Policy': 'foreignpolicy.com',
@@ -144,4 +145,5 @@ const defaultSites = {
   'Wired': 'wired.com',
   'World Politics Review': 'worldpoliticsreview.com',
   '*General Paywall Bypass*': 'generalpaywallbypass'
+  
 };

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -145,5 +145,4 @@ const defaultSites = {
   'Wired': 'wired.com',
   'World Politics Review': 'worldpoliticsreview.com',
   '*General Paywall Bypass*': 'generalpaywallbypass'
-  
 };


### PR DESCRIPTION
Sorry about that but I tested and Financialpost.com works with the bypass. 