### PR TITLE
Update NZ Herald to bypass site update

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -179,7 +179,7 @@ const blockedRegexes = {
   'lastampa.it': /.+\.repstatic\.it\/minify\/sites\/lastampa\/.+\/config\.cache\.php\?name=social_js/,
   'lrb.co.uk': /.+\.tinypass\.com\/.+/,
   'medscape.com': /.+\.medscapestatic\.com\/.*medscape-library\.js/,
-  'nzherald.co.nz': /nzherald\.co\.nz\/.+\/headjs\/.+\.js/,
+  'nzherald.co.nz': /(.+nzherald\.co\.nz\/.+\/subs\/p\.js|.+nzherald\.co\.nz\/.+\/default\.js|.+\/newsbarscript\.js)/,
   'interest.co.nz': /(.+\.presspatron\.com.+|.+interest\.co\.nz.+pp-ablock-banner\.js)/,
   'repubblica.it': /scripts\.repubblica\.it\/pw\/pw\.js.+/,
   'spectator.co.uk': /.+\.tinypass\.com\/.+/,

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -134,20 +134,13 @@ if (matchDomain('elmercurio.com')) {
   const counter = document.getElementById('article-counter');
   removeDOMElement(counter);
 } else if (matchDomain('nzherald.co.nz')) {
-  const paywall = document.getElementById('article-content');
-  if (paywall) {
-    const premium = document.getElementsByClassName('premium-sub')[0];
-    removeDOMElement(premium);
-    paywall.classList.remove('premium-content');
-    paywall.classList.add('full-content');
-    removeClassesByPrefix(paywall, 'QUnW');
-    const paras = paywall.querySelectorAll('p, span, h2, div');
-    for (const el of paras) {
-      removeClassesByPrefix(el, 'QUnW');
-      el.classList.remove('ellipsis');
-      el.removeAttribute('style');
-    }
+  const childItems = document.querySelector('.article__body').getElementsByTagName('*');
+  for (const el of childItems) {
+    el.removeAttribute('class');
+    el.removeAttribute('style');
   }
+  const overlay = document.querySelector('#premium-toaster');
+  removeDOMElement(overlay);
 } else if (matchDomain('interest.co.nz')) {
   const wrapper = document.getElementById('pp-ablock-banner-wrapper');
   const overlay = document.querySelector('.black-overlay');

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -135,9 +135,17 @@ if (matchDomain('elmercurio.com')) {
   removeDOMElement(counter);
 } else if (matchDomain('nzherald.co.nz')) {
   const childItems = document.querySelector('.article__body').getElementsByTagName('*');
+  let classHidden = '';
   for (const el of childItems) {
-    el.removeAttribute('class');
-    el.removeAttribute('style');
+    if (el.getAttribute('class')!=null && classHidden=='') {
+        classHidden = el.getAttribute('class');
+    }
+  }
+  if (classHidden!='') {
+    for (const el of childItems) {
+      el.classList.remove(classHidden);
+      el.removeAttribute('style');
+    }
   }
   const overlay = document.querySelector('#premium-toaster');
   removeDOMElement(overlay);


### PR DESCRIPTION
NZ Herald changed their paywall implementation today, so this makes changes to suit. The function 'removeClassesByPrefix' which was originally added for NZ Herald bypass has not been removed because it is now used by technologyreview.com bypass.