### PR TITLE
remove paywall in newyorker.com

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -476,6 +476,9 @@ if (matchDomain('elmercurio.com')) {
   document.querySelectorAll('div[class*="fancybox"]').forEach(function (el) {
     removeDOMElement(el);
   });
+} else if (matchDomain('newyorker.com')) {
+  const paywall = document.querySelector('.paywall-bar');
+  removeDOMElement(paywall);
 }
 
 function matchDomain (domains) {


### PR DESCRIPTION
Go to a New Yorker article (e.g. https://www.newyorker.com/magazine/2015/03/16/girl-interrupted) and notice the unsightly div at the bottom.