### PR TITLE
Prevent bottom dock from appearing in nytimes.com

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -270,18 +270,18 @@ if (matchDomain('elmercurio.com')) {
   const previewButton = document.querySelector('.css-3s1ce0');
   if (previewButton) { previewButton.click(); }
   // Prevent bottom dock from appearing
-  new MutationObserver(function(mutations) {
-    for(let mutation of mutations) {
-      for(let node of mutation.addedNodes) {
-        if (node instanceof HTMLElement) {
-          if (node.matches(".css-3fbowa")) {	
+  new window.MutationObserver(function (mutations) {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof window.HTMLElement) {
+          if (node.matches('.css-3fbowa')) {
             removeDOMElement(node);
             this.disconnect();
           }
         }
       }
     }
-  }).observe(document, {subtree: true, childList: true});
+  }).observe(document, { subtree: true, childList: true });
 } else if (matchDomain('technologyreview.com')) {
   // The class of banner is like 'overlayFooter__wrapper--3DhFn', which is hard to select exactly
   const subscribeBanner = document.querySelector('[class*=overlayFooter__wrapper]');

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -269,6 +269,19 @@ if (matchDomain('elmercurio.com')) {
 } else if (matchDomain('nytimes.com')) {
   const previewButton = document.querySelector('.css-3s1ce0');
   if (previewButton) { previewButton.click(); }
+  // Prevent bottom dock from appearing
+  new MutationObserver(function(mutations) {
+    for(let mutation of mutations) {
+      for(let node of mutation.addedNodes) {
+        if (node instanceof HTMLElement) {
+          if (node.matches(".css-3fbowa")) {	
+            removeDOMElement(node);
+            this.disconnect();
+          }
+        }
+      }
+    }
+  }).observe(document, {subtree: true, childList: true});
 } else if (matchDomain('technologyreview.com')) {
   // The class of banner is like 'overlayFooter__wrapper--3DhFn', which is hard to select exactly
   const subscribeBanner = document.querySelector('[class*=overlayFooter__wrapper]');


### PR DESCRIPTION
Go to a [NYTimes article](https://www.nytimes.com/interactive/2020/10/15/us/coronavirus-cases-us-surge.html?action=click&module=Top%20Stories&pgtype=Homepage) and notice the dock on the bottom annoying you to log in