### PR TITLE
Remove paywall bar on vanityfair.com

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -468,6 +468,9 @@ if (matchDomain('elmercurio.com')) {
 } else if (matchDomain('newyorker.com')) {
   const paywall = document.querySelector('.paywall-bar');
   removeDOMElement(paywall);
+} else if (matchDomain('vanityfair.com')) {
+  const paywall = document.querySelector('.paywall-bar');
+  removeDOMElement(paywall);
 } else if (matchDomain('delfi.ee')) {
   // Remove 'adblocker-detected' notification overlay
   document.body.classList.remove('adb-curtain');


### PR DESCRIPTION
Removes paywall bar blocking the bottom third of the [page ](https://www.vanityfair.com/hollywood/2020/10/netflix-rebecca-movie-review)