### PR TITLE
Add installation instructions for Microsoft Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 *Bypass Paywalls is a web browser extension to help bypass paywalls for selected sites.*
 
 ### Installation Instructions
-**Google Chrome** (Custom sites supported)
+**Google Chrome / Microsoft Edge** (Custom sites supported)
 1. Download this repo as a [ZIP file from GitHub](https://github.com/iamadamdev/bypass-paywalls-chrome/archive/master.zip).
 1. Unzip the file and you should have a folder named `bypass-paywalls-chrome-master`.
-1. In Chrome go to the extensions page (`chrome://extensions`).
+1. In Chrome/Edge go to the extensions page (`chrome://extensions` or `edge://extensions`).
 1. Enable Developer Mode.
 1. Drag the `bypass-paywalls-chrome-master` folder anywhere on the page to import it (do not delete the folder afterwards).
 


### PR DESCRIPTION
The instructions for the new Chromium-based Edge are the same as those for Chrome. This updates the README to explicitly spell that out.