### PR TITLE
New Yorker: Fixed article images not loading

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -231,8 +231,7 @@ const blockedRegexes = {
   'lesechos.fr': /.+\.tinypass\.com\/.+/,
   'washingtonpost.com': /.+\.washingtonpost\.com\/.+\/pwapi-proxy\.min\.js/,
   'thehindu.com': /ajax\.cloudflare\.com\/cdn-cgi\/scripts\/.+\/cloudflare-static\/rocket-loader\.min\.js/,
-  'technologyreview.com': /.+\.blueconic\.net\/.+/,
-  'newyorker.com': /.+\.newyorker\.com\/verso\/static\/presenter-articles.+\.js/
+  'technologyreview.com': /.+\.blueconic\.net\/.+/
 };
 
 const userAgentDesktop = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -463,8 +463,8 @@ if (matchDomain('elmercurio.com')) {
     removeDOMElement(el);
   });
 } else if (matchDomain('newyorker.com')) {
-  const paywall = document.querySelector('.paywall-bar');
-  removeDOMElement(paywall);
+  blockElement('.paywall-bar');
+  blockElement('.paywall-modal');
 } else if (matchDomain('vanityfair.com')) {
   const paywall = document.querySelector('.paywall-bar');
   removeDOMElement(paywall);


### PR DESCRIPTION
Fix for this [PR](https://github.com/iamadamdev/bypass-paywalls-chrome/issues/1049)

Undoes this [commit](https://github.com/iamadamdev/bypass-paywalls-chrome/commit/fff7f483db947e690977bfc80955a53329d3d349)