### PR TITLE
newyorker.com: Always block bottom paywall bar

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -456,7 +456,7 @@ if (matchDomain('elmercurio.com')) {
     removeDOMElement(el);
   });
 } else if (matchDomain('newyorker.com')) {
-  blockElement('.paywall-bar');
+  blockElement('.paywall-bar', true);
   blockElement('.paywall-modal');
 } else if (matchDomain('vanityfair.com')) {
   const paywall = document.querySelector('.paywall-bar');


### PR DESCRIPTION
Block paywall bar on https://www.newyorker.com/magazine/2020/12/14/why-do-we-still-love-the-office?utm_medium=social&utm_brand=tny&mbid=social_facebook&utm_source=facebook&utm_social-type=owned&fbclid=IwAR3kFNs08KlWMHrS37-JTajAFnXD-AM6grveHT6fIuqO3HAtQvOq2Oi-N3c