### PR TITLE
Added ambito.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 [Adweek](https://www.adweek.com)\
 [Algemeen Dagblad](https://www.ad.nl)\
 [American Banker](https://www.americanbanker.com)\
+[Ámbito](https://www.ambito.com/)\
 [Baltimore Sun](https://www.baltimoresun.com)\
 [Barron's](https://www.barrons.com)\
 [Bloomberg Quint](https://www.bloombergquint.com)\

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -12,6 +12,7 @@
     "*://*.ad.nl/*",
     "*://*.afr.com/*",
     "*://*.americanbanker.com/*",
+    "*://*.ambito.com/*",
     "*://*.bizjournals.com/*",
     "*://*.bloomberg.com/*",
     "*://*.bloombergquint.com/*",
@@ -257,7 +258,8 @@
     "*://*.bd.nl/*",
     "*://*.tubantia.nl/*",
     "*://*.pzc.nl/*",
-    "*://*.destentor.nl/*"
+    "*://*.destentor.nl/*",
+    "*://*.ambito/*"
   ],
   "version": "1.7.8"
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -137,6 +137,7 @@ const removeCookiesSelectHold = {
 // select only specific cookie(s) to drop from removeCookies domains
 const removeCookiesSelectDrop = {
   'ad.nl': ['temptationTrackingId'],
+  'ambito.com': ['TDNotesRead'],
   'bd.nl': ['temptationTrackingId'],
   'bndestem.nl': ['temptationTrackingId'],
   'demorgen.be': ['TID_ID'],

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -2,6 +2,7 @@
 const defaultSites = {
   'Adweek': 'adweek.com',
   'Algemeen Dagblad': 'ad.nl',
+  '\u00C1mbito': 'ambito.com',
   'American Banker': 'americanbanker.com',
   'Baltimore Sun': 'baltimoresun.com',
   'Barron\'s': 'barrons.com',


### PR DESCRIPTION
https://www.ambito.com

The paywall / login wall is shown when a user sees more than an amount of articles (`40` if i'm not mistaken). The amount of articles that a user has read is stored on a cookie called `TDNotesRead`. This PR aims to erase that cookie in order to prevent the soft paywall / login wall.