### PR TITLE
Support for gelocal group (italian newspapers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 [Postimees](https://www.postimees.ee)\
 [Quartz](https://qz.com)\
 [Quora](https://www.quora.com)\
+[Quotidiani Gelocal](https://quotidiani.gelocal.it)\
 [Republic.ru](https://republic.ru)\
 [San Diego Union Tribune](https://www.sandiegouniontribune.com)\
 [San Francisco Chronicle](https://www.sfchronicle.com)\

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -30,6 +30,7 @@
     "*://*.examiner.com.au/*",
     "*://*.firstthings.com/*",
     "*://*.ft.com/*",
+    "*://*.gelocal.it/*",
     "*://*.grubstreet.com/*",
     "*://*.haaretz.co.il/*",
     "*://*.humo.be/*",
@@ -152,6 +153,7 @@
     "*://*.fortune.com/*",
     "*://*.ft.com/*",
     "*://*.genomeweb.com/*",
+    "*://*.gelocal.it/*",
     "*://*.glassdoor.com/*",
     "*://*.globes.co.il/*",
     "*://*.groene.nl/*",
@@ -265,5 +267,5 @@
     "*://*.spectator.us/*",
     "*://*.humo.be/*"
   ],
-  "version": "1.7.8"
+  "version": "1.7.9"
 }

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -267,5 +267,5 @@
     "*://*.spectator.us/*",
     "*://*.humo.be/*"
   ],
-  "version": "1.7.9"
+  "version": "1.7.8"
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -23,6 +23,7 @@ const allowCookies = [
   'ed.nl',
   'examiner.com.au',
   'ft.com',
+  'gelocal.it',
   'gelderlander.nl',
   'grubstreet.com',
   'harpers.org',

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -531,8 +531,6 @@ if (matchDomain('elmercurio.com')) {
 } else if (matchDomain('gelocal.it')) {
   const paywallAdagio = document.querySelector('.paywall-adagio');
   const articleBody = document.getElementById('article-body');
-  console.log(paywallAdagio)
-  console.log(articleBody)
   if (paywallAdagio) {
     removeDOMElement(paywallAdagio);
   }

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -528,6 +528,17 @@ if (matchDomain('elmercurio.com')) {
     bodySingle.classList.remove('single');
     window.location.href = ampHtml.href;
   }
+} else if (matchDomain('gelocal.it')) {
+  const paywallAdagio = document.querySelector('.paywall-adagio');
+  const articleBody = document.getElementById('article-body');
+  console.log(paywallAdagio)
+  console.log(articleBody)
+  if (paywallAdagio) {
+    removeDOMElement(paywallAdagio);
+  }
+  if (articleBody) {
+    articleBody.style.maxHeight = null;
+  }
 }
 
 function matchDomain (domains) {

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -97,6 +97,7 @@ const defaultSites = {
   'PZC': 'pzc.nl',
   'Quartz (free articles only)': 'qz.com',
   'Quora': 'quora.com',
+  'Quotidiani Gelocal': 'gelocal.it',
   'Republic.ru': 'republic.ru',
   'San Diego Union Tribune': 'sandiegouniontribune.com',
   'San Francisco Chronicle': 'sfchronicle.com',


### PR DESCRIPTION
I added support for newspapers belonging to [gelocal group](https://quotidiani.gelocal.it/edicola/home.jsp) (Italian network of local newspapers)