### PR TITLE
Add Speld.nl (Dutch parody news site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 [De Gelderlander](https://www.gelderlander.nl)\
 [De Groene Amsterdammer](https://www.groene.nl)\
 [De Stentor](https://www.destentor.nl)\
+[De Speld](https://speld.nl)\
 [De Tijd](https://www.tijd.be)\
 [De Volkskrant](https://www.volkskrant.nl)\
 [DELFI](https://www.delfi.ee)\

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -217,6 +217,7 @@
     "*://*.sofrep.com/*",
     "*://*.spectator.co.uk/*",
     "*://*.spectator.com.au/*",
+    "*://*.speld.nl/",
     "*://*.statista.com/*",
     "*://*.stuff.co.nz/*",
     "*://*.sun-sentinel.com/*",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -115,6 +115,7 @@ const removeCookies = [
   'seattletimes.com',
   'sofrep.com',
   'spectator.co.uk',
+  'speld.nl',
   'telegraaf.nl',
   'theadvocate.com.au',
   'theage.com.au',

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -47,6 +47,7 @@ const allowCookies = [
   'seekingalpha.com',
   'sofrep.com',
   'spectator.co.uk',
+  'speld.nl',
   'tubantia.nl',
   'techinasia.com',
   'telegraaf.nl',
@@ -153,7 +154,8 @@ const removeCookiesSelectDrop = {
   'humo.be': ['TID_ID'],
   'nrc.nl': ['counter'],
   'pzc.nl': ['temptationTrackingId'],
-  'tubantia.nl': ['temptationTrackingId']
+  'tubantia.nl': ['temptationTrackingId'],
+  'speld.nl': ['speld-paywall']
 };
 
 // Override User-Agent with Googlebot

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -591,6 +591,9 @@ if (matchDomain('elmercurio.com')) {
     const advertising = document.querySelectorAll('.advertising, amp-embed');
     removeDOMElement(...advertising);
   }
+} else if (matchDomain('speld.nl')) {
+    const paywallPopup = document.querySelector('.c-paywall-notice');
+    removeDOMelement(paywallPopup);
 }
 
 function matchDomain (domains) {

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -593,7 +593,7 @@ if (matchDomain('elmercurio.com')) {
   }
 } else if (matchDomain('speld.nl')) {
     const paywallPopup = document.querySelector('.c-paywall-notice');
-    removeDOMelement(paywallPopup);
+    removeDOMElement(paywallPopup);
 }
 
 function matchDomain (domains) {

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -23,6 +23,7 @@ const defaultSites = {
   'De Groene Amsterdammer': 'groene.nl',
   'DeMorgen': 'demorgen.be',
   'Denver Post': 'denverpost.com',
+  'De Speld': 'speld.nl',
   'De Stentor': 'destentor.nl',
   'De Tijd': 'tijd.be',
   'de Volkskrant': 'volkskrant.nl',


### PR DESCRIPTION
Speld.nl is a popular parody new site in The Netherlands, not unlike The Onion.

The paywall is a max-number-of-visits type. The visits are tracked in a cookie, which this PR selectively removes to not trigger the cookie consent forms each time. We also remove a popup that says how many visits you've got left.