### PR TITLE
Fixes and Added another site

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -596,6 +596,20 @@ if (matchDomain('elmercurio.com')) {
 } else if (matchDomain('speld.nl')) {
   const paywallPopup = document.querySelector('.c-paywall-notice');
   removeDOMElement(paywallPopup);
+} else if (matchDomain('centralwesterndaily.com.au')) {
+  const subscriberHider = document.querySelector('.subscriber-hider');
+  if (subscriberHider) {
+    subscriberHider.classList.remove('subscriber-hider');
+  }
+  const subscribeTruncate = document.querySelector('.subscribe-truncate');
+  removeDOMElement(subscribeTruncate);
+} else if (matchDomain('dailyliberal.com.au')) {
+  const subscriberHider = document.querySelector('.subscriber-hider');
+  if (subscriberHider) {
+    subscriberHider.classList.remove('subscriber-hider');
+  }
+  const subscribeTruncate = document.querySelector('.subscribe-truncate');
+  removeDOMElement(subscribeTruncate);
 }
 
 function matchDomain (domains) {

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -18,6 +18,7 @@ const defaultSites = {
   'Chicago Tribune': 'chicagotribune.com',
   'Corriere Della Sera': 'corriere.it',
   'Crain\'s Chicago Business': 'chicagobusiness.com',
+  'Daily Liberal': 'dailyliberal.com.au',
   'Daily Press': 'dailypress.com',
   'De Gelderlander': 'gelderlander.nl',
   'De Groene Amsterdammer': 'groene.nl',


### PR DESCRIPTION
Fixed centralwesterndauly.com.au as it wasn't working.
Also added support for dailyliberal.com.au.

Allot of Australian regional news sites use very similar sites, and currently in the process of testing other regional Australian newspaper sites.

PS: This is my first fork and pull request. If I am missing something, let me know.