### PR TITLE
Add latimes.com

### DIFF
--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -645,14 +645,12 @@ if (matchDomain('elmercurio.com')) {
   }
 } else if (matchDomain('latimes.com')) {
   const paywall = document.querySelector('metering-modal');
+  const incognitoWall = document.querySelector('metering-toppanel');
   if (paywall) {
     removeDOMElement(paywall);
-  } else {
-    const incognitoWall = document.querySelector('metering-toppanel');
-    if (incognitoWall) {
+  } else if (incognitoWall) {
       removeDOMElement(incognitoWall);
     }
-  }
   if (paywall || incognitoWall) {
     document.body.removeAttribute('style');
   }

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -643,6 +643,19 @@ if (matchDomain('elmercurio.com')) {
   if (body) {
     body.removeAttribute('class');
   }
+} else if (matchDomain('latimes.com')) {
+  const paywall = document.querySelector('metering-modal');
+  if (paywall) {
+    removeDOMElement(paywall);
+  } else {
+    const incognitoWall = document.querySelector('metering-toppanel');
+    if (incognitoWall) {
+      removeDOMElement(incognitoWall);
+    }
+  }
+  if (paywall || incognitoWall) {
+    document.body.removeAttribute('style');
+  }
 }
 
 function matchDomain (domains) {


### PR DESCRIPTION
Adds paywall removal for "subscriber exclusives", along with their "You’re using a browser set to private or incognito mode" wall. The latter is only visible on Firefox private window, and not Chrome incognito.

It looks as though `latimes.com` used to be part of this extension but was removed, as all the supporting changes were already done in the readme, manifest, etc...