### PR TITLE
Add nationalgeographic.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 [Adweek](https://www.adweek.com)\
 [Algemeen Dagblad](https://www.ad.nl)\
 [American Banker](https://www.americanbanker.com)\
-[Ámbito](https://www.ambito.com/)\
+[Ámbito](https://www.ambito.com)\
 [Baltimore Sun](https://www.baltimoresun.com)\
 [Barron's](https://www.barrons.com)\
 [Bloomberg Quint](https://www.bloombergquint.com)\
@@ -54,12 +54,12 @@
 [DeMorgen](https://www.demorgen.be)\
 [Denver Post](https://www.denverpost.com)\
 [Diario Financiero](https://www.df.cl)\
-[Domani](https://www.editorialedomani.it/)\
+[Domani](https://www.editorialedomani.it)\
 [Dynamed Plus](https://www.dynamed.com)\
 [Eindhovens Dagblad](https://www.ed.nl)\
 [El Mercurio](https://www.elmercurio.com)\
-[El Pais](https://www.elpais.com/)\
-[El Periodico](https://www.elperiodico.com/)\
+[El Pais](https://www.elpais.com)\
+[El Periodico](https://www.elperiodico.com)\
 [Elu24](https://www.elu24.ee)\
 [Encyclopedia Britannica](https://www.britannica.com)\
 [Estadão](https://www.estadao.com.br)\
@@ -95,7 +95,7 @@
 [La Repubblica](https://www.repubblica.it)\
 [La Stampa](https://www.lastampa.it)\
 [La Tercera](https://www.latercera.com)\
-[La Voix du Nord](https://www.lavoixdunord.fr/)\
+[La Voix du Nord](https://www.lavoixdunord.fr)\
 [Le Devoir](https://www.ledevoir.com)\
 [Le Parisien](https://www.leparisien.fr)\
 [Les Échos](https://www.lesechos.fr)\
@@ -108,7 +108,8 @@
 [Medscape](https://www.medscape.com)\
 [Mexicon News Daily](https://mexiconewsdaily.com)\
 [Mountain View Voice](https://www.mv-voice.com)\
-[New York Daily News](https://www.nydailynews.com/)\
+[National Geographic](https://www.nationalgeographic.com)\
+[New York Daily News](https://www.nydailynews.com)\
 [NRC Handelsblad](https://www.nrc.nl)\
 [NT News](https://www.ntnews.com.au)\
 [National Post](https://www.nationalpost.com)\
@@ -187,7 +188,7 @@
 [Tubantia](https://www.tubantia.nl)\
 [Vanity Fair](https://www.vanityfair.com)\
 [Vrij Nederland](https://www.vn.nl)\
-[Vulture](https://www.vulture.com/)\
+[Vulture](https://www.vulture.com)\
 [Winston-Salem Journal](https://journalnow.com)\
 [Wired](https://www.wired.com)\
 [World Politics Review](https://www.worldpoliticsreview.com)\

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -193,6 +193,7 @@
     "*://*.medscape.com/*",
     "*://*.mercurynews.com/*",
     "*://*.mv-voice.com/*",
+    "*://*.nationalgeographic.com",
     "*://*.nationalpost.com/*",
     "*://*.news-gazette.com/*",
     "*://*.newstatesman.com/*",

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -687,6 +687,27 @@ if (matchDomain('elmercurio.com')) {
       button.click();
     }
   }
+} else if (matchDomain('nationalgeographic.com')) {
+  //prevent modal from showing up, then remove scroll-locking, and article blur
+  new window.MutationObserver(function (mutations) {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node instanceof window.HTMLElement) {
+          if (node.matches('#fittPortal_0')) {
+            removeDOMElement(node);
+            const body = document.body;
+            body.removeAttribute('class');
+            body.removeAttribute('style');
+            body.removeAttribute('overflow');
+            const blur = document.querySelector('#natgeo-template1-frame-1-module-1 > div > div > section > article > section > div.Article__Content__Overlay--gated');
+            if (blur) removeDOMElement(blur);
+
+            this.disconnect(); // Stop watching for element being added after one removal
+          }
+        }
+      }
+    }
+  }).observe(document, { subtree: true, childList: true });
 }
 
 function matchDomain (domains) {
@@ -735,7 +756,7 @@ function pageContains (selector, text) {
 }
 
 // Prevent element from being added the first time to the DOM
-function blockElement (selector, blockAlways = false) {
+function blockElement (selector, blockAlways = false, callback = null) {
   new window.MutationObserver(function (mutations) {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -756,7 +756,7 @@ function pageContains (selector, text) {
 }
 
 // Prevent element from being added the first time to the DOM
-function blockElement (selector, blockAlways = false, callback = null) {
+function blockElement (selector, blockAlways = false) {
   new window.MutationObserver(function (mutations) {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -84,6 +84,7 @@ const defaultSites = {
   'MIT Sloan Management Review': 'sloanreview.mit.edu',
   'MIT Technology Review': 'technologyreview.com',
   'Mountain View Voice': 'mv-voice.com',
+  'National Geographic': 'nationalgeographic.com',
   'National Post': 'nationalpost.com',
   'Neue Zürcher Zeitung': 'nzz.ch',
   'New Statesman': 'newstatesman.com',


### PR DESCRIPTION
Also fixed the `README.md` links, which fail to parse correctly in some implementations due to the trailing backslash.

Paywall removal implementation uses a form of the `blockElement()` fcn, but with some additional actions. I can look into just modifying `blockElement()` to include a callback of sorts without breaking any other uses of the function.