### PR TITLE
Fix wapo

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -74,7 +74,8 @@ const allowCookies = [
   'time.com',
   'zeit.de',
   'expansion.com',
-  'dailytelegraph.com.au'
+  'dailytelegraph.com.au',
+  'washingtonpost.com'
 ];
 
 // Removes cookies after page load
@@ -122,7 +123,8 @@ const removeCookies = [
   'vn.nl',
   'vulture.com',
   'wsj.com',
-  'medium.com'
+  'medium.com',
+  'washingtonpost.com'
 ];
 
 // Contains remove cookie sites above plus any custom sites

--- a/src/js/contentScript.js
+++ b/src/js/contentScript.js
@@ -79,7 +79,8 @@ if (matchDomain('elmercurio.com')) {
 } else if (matchDomain('washingtonpost.com')) {
   const leaderboard = document.querySelector('#leaderboard-wrapper');
   const adverts = document.querySelectorAll('div[data-qa="article-body-ad"]');
-  removeDOMElement(leaderboard, ...adverts);
+  const softwall = document.querySelector('[id^="softwall"]');
+  removeDOMElement(leaderboard, softwall, ...adverts);
   if (window.location.href.includes('/gdpr-consent/')) {
     const freeButton = document.querySelector('.gdpr-consent-container .continue-btn.button.free');
     if (freeButton) { freeButton.click(); }


### PR DESCRIPTION
Wapo is currently stuck in a loop if enabled in supported sites, but adding it to custom sites works. This PR fixes this issue and also removes the soft paywall banner at the bottom not currently blocked by adblockers like ublock