### PR TITLE
Add support for ilmessaggero.it

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@
 [History Extra](https://www.historyextra.com)\
 [Humo](https://www.humo.be)\
 [Il Manifesto](https://www.ilmanifesto.it)\
+[Il Messaggero](https://www.ilmessaggero.it)\
 [Inc.com](https://www.inc.com)\
 [Interest.co.nz](https://www.interest.co.nz)\
 [Investors Chronicle](https://www.investorschronicle.co.uk)

--- a/manifest-ff.json
+++ b/manifest-ff.json
@@ -34,6 +34,7 @@
     "*://*.grubstreet.com/*",
     "*://*.haaretz.co.il/*",
     "*://*.humo.be/*",
+    "*://*.ilmessaggero.it/*",
     "*://*.interest.co.nz/*",
     "*://*.ledevoir.com/*",
     "*://*.leparisien.fr/*",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -248,7 +248,8 @@ const blockedRegexes = {
   'latimes.com': /(metering\.platform\.latimes\.com\/|cdn\.ampproject\.org\/v\d\/amp-(access|subscriptions)-.+\.js)/,
   'theathletic.com': /cdn\.ampproject\.org\/v\d\/amp-(access|subscriptions)-.+\.js/,
   'japantimes.co.jp': /cdn\.cxense\.com\//,
-  'scmp.com': /(\.tinypass\.com\/|cdn\.ampproject\.org\/v\d\/amp-access-.+\.js)/
+  'scmp.com': /(\.tinypass\.com\/|cdn\.ampproject\.org\/v\d\/amp-access-.+\.js)/,
+  'ilmessaggero.it': /(utils\.cedsdigital\.it\/js\/PaywallMeter\.js)/
 };
 
 const userAgentDesktop = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';

--- a/src/js/sites.js
+++ b/src/js/sites.js
@@ -62,6 +62,7 @@ const defaultSites = {
   'History Extra': 'historyextra.com',
   'Humo': 'humo.be',
   'Il Manifesto': 'ilmanifesto.it',
+  'Il Messaggero': 'ilmessaggero.it',
   'Inc.com': 'inc.com',
   'Interest NZ': 'interest.co.nz',
   'Investors Chronicle': 'investorschronicle.co.uk',


### PR DESCRIPTION
Hi,

this PR adds support for Il Messaggero, quite famous newspaper in Italy.

Sample paywalled article [here](https://www.ilmessaggero.it/italia/dipendenti_si_ribellano_smart_working_bollette_ufficio_ultime_notizie-7020361.html).

Thanks 🙏